### PR TITLE
Fix H3 SLA wrapper chaining and sampler state with forecasted steps

### DIFF
--- a/.github/workflows/h3-sla-tests.yml
+++ b/.github/workflows/h3-sla-tests.yml
@@ -1,0 +1,47 @@
+name: H3 SLA compatibility tests
+
+on:
+  pull_request:
+    paths:
+      - "ComfyUI-H3-SLA-Attention/**"
+      - ".github/workflows/h3-sla-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "ComfyUI-H3-SLA-Attention/**"
+      - ".github/workflows/h3-sla-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  wrapper-contract:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Compile SLA wrapper code
+        run: |
+          python -m py_compile \
+            ComfyUI-H3-SLA-Attention/sla/patch.py \
+            ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+
+      - name: Run dependency-free wrapper-chain regression tests
+        run: |
+          python -m unittest discover \
+            -s ComfyUI-H3-SLA-Attention/tests \
+            -p 'test_wrapper_chain.py' \
+            -v

--- a/ComfyUI-H3-SLA-Attention/sla/patch.py
+++ b/ComfyUI-H3-SLA-Attention/sla/patch.py
@@ -33,7 +33,10 @@ def _new_state():
     return {
         "calls": 0,        # sparse invocations this run
         "dense": 0,        # fall-throughs this run
-        "step": 0,
+        "step": 0,         # logical sampler step, 1-based
+        "n_steps": 0,
+        "last_step_index": None,
+        "summarized": False,
         "seq": 0,
         "kept": 0,
         "blocks": 0,
@@ -41,6 +44,21 @@ def _new_state():
         "backend": None,   # what we displaced
         "failed": None,    # first kernel failure, if any
     }
+
+
+def _reset_run_state(state):
+    """Reset per-sampling-run counters while preserving the displaced backend."""
+    state["calls"] = 0
+    state["dense"] = 0
+    state["step"] = 0
+    state["n_steps"] = 0
+    state["last_step_index"] = None
+    state["summarized"] = False
+    state["seq"] = 0
+    state["kept"] = 0
+    state["blocks"] = 0
+    state["pinned"] = 0
+    state["failed"] = None
 
 
 def _summarise(state, sparsity, blkq, blkk):
@@ -157,26 +175,123 @@ def _call_next_wrapper(executor, *args, **kwargs):
     return executor.original(*args, **kwargs)
 
 
+def _sequence_scalar(value):
+    """Return the first scalar from a Python sequence, or None when unavailable."""
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        return float(value[0])
+    return None
+
+
+def _resolve_sampler_step(transformer_options):
+    """Resolve the logical sampler step from ComfyUI's current/raw sigmas.
+
+    Spectrum can forecast a sampler step without invoking the diffusion model at
+    all. Counting wrapper invocations therefore counts *actual NFEs*, not sampler
+    steps. ComfyUI exposes both the complete schedule (``sample_sigmas``) and the
+    current raw sigma (``sigmas``), which lets SLA recover the real sampler
+    position even when some intermediate model calls were skipped.
+    """
+    sample_sigmas = transformer_options.get("sample_sigmas")
+    current_sigmas = transformer_options.get("sigmas")
+    if sample_sigmas is None or current_sigmas is None:
+        return None
+
+    try:
+        n_steps = len(sample_sigmas) - 1
+    except TypeError:
+        return None
+    if n_steps < 1:
+        return None
+
+    # Keep dependency-free tests cheap and avoid requiring a Torch stub that
+    # implements tensor reductions.
+    if isinstance(sample_sigmas, (list, tuple)):
+        current = _sequence_scalar(current_sigmas)
+        if current is None:
+            try:
+                current = float(current_sigmas)
+            except (TypeError, ValueError):
+                return None
+        try:
+            values = [float(v) for v in sample_sigmas[:-1]]
+        except (TypeError, ValueError):
+            return None
+        if not values:
+            return None
+        step_index = min(range(len(values)), key=lambda i: abs(values[i] - current))
+        return step_index, n_steps
+
+    try:
+        schedule = sample_sigmas.reshape(-1)
+        current = current_sigmas.reshape(-1)
+        if schedule.numel() < 2 or current.numel() == 0:
+            return None
+        current_value = current[0].to(device=schedule.device, dtype=schedule.dtype)
+        step_index = int(torch.argmin(torch.abs(schedule[:-1] - current_value)).item())
+        return step_index, int(schedule.numel()) - 1
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _prepare_run_state(state, transformer_options, sparsity_ratio, blkq, blkk):
+    """Synchronize SLA's run state with the real sampler schedule.
+
+    Returns ``n_steps``. When current sigma metadata is unavailable, this falls
+    back to the historical invocation counter so non-standard callers remain
+    compatible.
+    """
+    resolved = _resolve_sampler_step(transformer_options)
+    if resolved is None:
+        n_steps = max(1, len(transformer_options.get("sample_sigmas", [])) - 1)
+        if state["step"] >= n_steps:
+            if not state["summarized"] and (state["calls"] or state["dense"]):
+                _summarise(state, sparsity_ratio, blkq, blkk)
+            _reset_run_state(state)
+        state["n_steps"] = n_steps
+        state["step"] += 1
+        return n_steps
+
+    step_index, n_steps = resolved
+    last_step_index = state["last_step_index"]
+    new_run = (
+        (state["n_steps"] not in (0, n_steps))
+        or (
+            last_step_index is not None
+            and (
+                step_index < last_step_index
+                or (state["summarized"] and step_index <= last_step_index)
+            )
+        )
+    )
+
+    if new_run:
+        if not state["summarized"] and (state["calls"] or state["dense"]):
+            _summarise(state, sparsity_ratio, blkq, blkk)
+        _reset_run_state(state)
+
+    state["n_steps"] = n_steps
+    state["step"] = step_index + 1
+    state["last_step_index"] = step_index
+    return n_steps
+
+
 def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps):
     """DIFFUSION_MODEL wrapper: per-step state, and the end-of-run summary.
 
     Registered once and then reused -- ComfyUI caches node outputs, so this
-    closure outlives a single sampling run. The step counter therefore has to
-    reset itself, or every run after the first drifts permanently into the
-    trailing-dense window and silently stops sparsifying.
+    closure outlives a single sampling run. Spectrum may skip diffusion-model
+    calls on forecasted steps, therefore SLA derives its logical step from
+    ``sample_sigmas`` + current ``sigmas`` instead of counting wrapper calls.
     """
 
     def wrapper(executor, x, timestep, context, transformer_options={},
                 minimax_payload=None, **kwargs):
         to = transformer_options
-        n_steps = max(1, len(to.get("sample_sigmas", [])) - 1)
-
-        if state["step"] >= n_steps:      # new run
-            state["step"] = 0
-            state["calls"] = 0
-            state["dense"] = 0
-            state["failed"] = None
-        state["step"] += 1
+        n_steps = _prepare_run_state(
+            state, to, sparsity_ratio, blkq, blkk
+        )
 
         # PackedLayout.segments is [(start, stop, kind), ...] over
         # [text | cond/ref | audio | video]; the video start is therefore the
@@ -210,8 +325,9 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps):
             **kwargs,
         )
 
-        if state["step"] >= n_steps:
+        if state["step"] >= n_steps and not state["summarized"]:
             _summarise(state, sparsity_ratio, blkq, blkk)
+            state["summarized"] = True
         return out
 
     return wrapper

--- a/ComfyUI-H3-SLA-Attention/sla/patch.py
+++ b/ComfyUI-H3-SLA-Attention/sla/patch.py
@@ -142,6 +142,21 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
     return override
 
 
+def _call_next_wrapper(executor, *args, **kwargs):
+    """Advance the ComfyUI wrapper chain instead of jumping to the base model.
+
+    Current ComfyUI ``WrapperExecutor`` instances are callable; calling them
+    advances to the next registered wrapper. Calling ``executor.original`` here
+    would bypass every wrapper installed after SLA (for example Spectrum's H3
+    instrumentation), which makes those patches silently lose the native model
+    call. The type fallback only preserves the tiny executor shims used by this
+    package's historical unit tests and older compatibility harnesses.
+    """
+    if not isinstance(executor, type) and callable(executor):
+        return executor(*args, **kwargs)
+    return executor.original(*args, **kwargs)
+
+
 def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps):
     """DIFFUSION_MODEL wrapper: per-step state, and the end-of-run summary.
 
@@ -186,9 +201,14 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps):
         # crash mid-sampling rather than the graceful no-op they should get.
         if minimax_payload is not None:
             kwargs["minimax_payload"] = minimax_payload
-        out = executor.original(x, timestep, context,
-                                transformer_options=transformer_options,
-                                **kwargs)
+        out = _call_next_wrapper(
+            executor,
+            x,
+            timestep,
+            context,
+            transformer_options=transformer_options,
+            **kwargs,
+        )
 
         if state["step"] >= n_steps:
             _summarise(state, sparsity_ratio, blkq, blkk)

--- a/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
@@ -1,0 +1,155 @@
+"""Regression tests for ComfyUI DIFFUSION_MODEL wrapper composition.
+
+This file deliberately avoids importing Triton or ComfyUI. It loads SLA's
+``patch.py`` with tiny dependency stubs and emulates the current ComfyUI
+``WrapperExecutor`` contract closely enough to prove that SLA advances the
+wrapper chain instead of jumping directly to the original model method.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PATCH = _ROOT / "sla" / "patch.py"
+_PACKAGE = "h3_sla_wrapper_chain_test"
+
+
+def _load_patch_module():
+    """Load patch.py without requiring torch, Triton, or a ComfyUI checkout."""
+
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = object()
+    torch_stub.float16 = object()
+    sys.modules.setdefault("torch", torch_stub)
+
+    package = types.ModuleType(_PACKAGE)
+    package.__path__ = [str(_ROOT)]
+    sys.modules[_PACKAGE] = package
+
+    sla_package = types.ModuleType(f"{_PACKAGE}.sla")
+    sla_package.__path__ = [str(_ROOT / "sla")]
+    sys.modules[f"{_PACKAGE}.sla"] = sla_package
+
+    block_map = types.ModuleType(f"{_PACKAGE}.sla.block_map")
+    block_map.get_block_map = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("attention routing is outside this wrapper-chain test")
+    )
+    sys.modules[block_map.__name__] = block_map
+
+    kernel = types.ModuleType(f"{_PACKAGE}.sla.kernel")
+    kernel.block_sparse_attention = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("attention kernel is outside this wrapper-chain test")
+    )
+    sys.modules[kernel.__name__] = kernel
+
+    spec = importlib.util.spec_from_file_location(
+        f"{_PACKAGE}.sla.patch",
+        _PATCH,
+        submodule_search_locations=None,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sla_patch = _load_patch_module()
+
+
+class WrapperExecutor:
+    """Minimal behavioral copy of ComfyUI's current WrapperExecutor."""
+
+    def __init__(self, original, wrappers, idx=0):
+        self.original = original
+        self.wrappers = list(wrappers)
+        self.idx = idx
+        self.is_last = idx == len(self.wrappers)
+
+    def __call__(self, *args, **kwargs):
+        return WrapperExecutor(self.original, self.wrappers, self.idx + 1).execute(
+            *args, **kwargs
+        )
+
+    def execute(self, *args, **kwargs):
+        if self.is_last:
+            return self.original(*args, **kwargs)
+        return self.wrappers[self.idx](self, *args, **kwargs)
+
+
+class WrapperChainRegression(unittest.TestCase):
+    def test_sla_advances_to_downstream_wrapper_before_original(self):
+        events = []
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(
+            state,
+            sparsity_ratio=0.90,
+            blkq=64,
+            blkk=64,
+            dense_last_steps=0,
+        )
+
+        def downstream(executor, *args, **kwargs):
+            events.append("downstream")
+            return executor(*args, **kwargs)
+
+        def original(*args, **kwargs):
+            events.append("original")
+            return "ok"
+
+        transformer_options = {"sample_sigmas": [1.0, 0.0]}
+        executor = WrapperExecutor(original, [sla_wrapper, downstream])
+        result = executor.execute(
+            object(),
+            object(),
+            object(),
+            transformer_options=transformer_options,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(events, ["downstream", "original"])
+
+    def test_h3_payload_is_forwarded_through_the_chain(self):
+        seen = {}
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 0)
+
+        def downstream(executor, *args, **kwargs):
+            seen.update(kwargs)
+            return executor(*args, **kwargs)
+
+        executor = WrapperExecutor(lambda *a, **k: None, [sla_wrapper, downstream])
+        payload = {"layout": None}
+        executor.execute(
+            object(),
+            object(),
+            object(),
+            transformer_options={"sample_sigmas": [1.0, 0.0]},
+            minimax_payload=payload,
+        )
+
+        self.assertIs(seen["minimax_payload"], payload)
+
+    def test_legacy_non_callable_test_executor_still_works(self):
+        """Keep compatibility with the package's older unit-test executor shim."""
+
+        seen = []
+
+        class LegacyExecutor:
+            @staticmethod
+            def original(*args, **kwargs):
+                seen.append("original")
+                return "ok"
+
+        result = sla_patch._call_next_wrapper(LegacyExecutor, 1, 2, three=3)
+        self.assertEqual(result, "ok")
+        self.assertEqual(seen, ["original"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
@@ -135,6 +135,86 @@ class WrapperChainRegression(unittest.TestCase):
 
         self.assertIs(seen["minimax_payload"], payload)
 
+    def test_spectrum_forecasts_do_not_merge_sla_run_state(self):
+        """Skipped NFEs must not make SLA count across independent sampler runs."""
+
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 0)
+        summaries = []
+        original_summarise = sla_patch._summarise
+
+        def capture_summary(current_state, *args):
+            summaries.append(current_state["calls"])
+
+        def downstream(executor, *args, **kwargs):
+            # MiniMax-H3 has 50 transformer blocks, hence 50 attention calls
+            # for each actual model evaluation.
+            state["calls"] += 50
+            return executor(*args, **kwargs)
+
+        executor = WrapperExecutor(lambda *a, **k: None, [sla_wrapper, downstream])
+
+        schedule19 = [float(19 - i) for i in range(20)]
+        schedule3 = [3.0, 2.0, 1.0, 0.0]
+
+        def run(schedule, actual_indices):
+            for idx in actual_indices:
+                executor.execute(
+                    object(),
+                    object(),
+                    object(),
+                    transformer_options={
+                        "sample_sigmas": schedule,
+                        "sigmas": [schedule[idx]],
+                    },
+                )
+
+        try:
+            sla_patch._summarise = capture_summary
+
+            # Mirrors the observed Spectrum patterns: 10/19 actuals, then
+            # 12/19 actuals, then two 2/3-actual refinement passes.
+            run(schedule19, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
+            run(schedule19, [0, 1, 3, 5, 7, 8, 10, 12, 14, 15, 17, 18])
+            run(schedule3, [0, 2])
+            run(schedule3, [0, 2])
+        finally:
+            sla_patch._summarise = original_summarise
+
+        self.assertEqual(summaries, [500, 600, 100, 100])
+        self.assertTrue(state["summarized"])
+        self.assertEqual(state["step"], 3)
+        self.assertEqual(state["last_step_index"], 2)
+
+    def test_dense_last_steps_uses_logical_sampler_position(self):
+        """Forecasted steps must not shift SLA's trailing-dense window."""
+
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 2)
+        dense_flags = []
+
+        def downstream(executor, *args, **kwargs):
+            dense_flags.append(kwargs["transformer_options"]["_h3sla_dense"])
+            return executor(*args, **kwargs)
+
+        executor = WrapperExecutor(lambda *a, **k: None, [sla_wrapper, downstream])
+        schedule = [float(19 - i) for i in range(20)]
+
+        # Only actual model evaluations reach SLA. Steps 17 and 18 are the
+        # logical last two sampler steps even though they are just calls 3/4.
+        for idx in [0, 5, 17, 18]:
+            executor.execute(
+                object(),
+                object(),
+                object(),
+                transformer_options={
+                    "sample_sigmas": schedule,
+                    "sigmas": [schedule[idx]],
+                },
+            )
+
+        self.assertEqual(dense_flags, [False, False, True, True])
+
     def test_legacy_non_callable_test_executor_still_works(self):
         """Keep compatibility with the package's older unit-test executor shim."""
 


### PR DESCRIPTION
## Summary

Fixes two MiniMax-H3 SLA integration issues that appear when the model is used together with wrappers that can skip or intercept diffusion-model evaluations, specifically Spectrum-style feature forecasting.

The changes keep SLA composable with ComfyUI's `DIFFUSION_MODEL` wrapper chain and make SLA's per-run state follow the actual sampler schedule rather than the number of model invocations.

## Problems

### 1. SLA bypassed downstream `DIFFUSION_MODEL` wrappers

The SLA wrapper called:

```python
executor.original(...)
```

directly.

With ComfyUI's `WrapperExecutor`, this jumps straight to the original diffusion model and bypasses every wrapper registered after SLA in the chain.

That breaks wrapper composition. In particular, Spectrum's H3 instrumentation can silently lose the native model call when SLA is ahead of it in the wrapper chain.

### 2. SLA treated model invocations as sampler steps

SLA's persistent state previously advanced its step counter once for every invocation of the diffusion-model wrapper.

That assumption is invalid when a forecasting/caching accelerator skips denoiser evaluations.

For example, a 19-step sampler may execute the actual H3 model only 10 or 12 times. Counting those NFEs as sampler positions causes state from one generation to spill into the next and also shifts `dense_last_steps` away from the real tail of the sampler schedule.

## Changes

### Preserve the ComfyUI wrapper chain

The SLA wrapper now advances through the current `WrapperExecutor` instead of calling `executor.original()` directly.

This preserves downstream wrappers while retaining a small compatibility fallback for the package's existing lightweight executor/test shims.

`minimax_payload` continues to be forwarded through the chain when H3 supplied it.

### Track the logical sampler position

SLA now resolves the current sampler step from ComfyUI's:

* `sample_sigmas`
* current `sigmas`

This separates two concepts that are not necessarily equivalent:

* **sampler step**
* **actual denoiser evaluation / NFE**

The resolved logical position is used for:

* run-boundary detection
* resetting persistent SLA state
* end-of-run summaries
* `dense_last_steps`

If the sigma metadata is unavailable, the previous invocation-counting behavior remains available as a compatibility fallback.

### Reset all per-run state consistently

Run reset logic is centralized so counters and state such as:

* sparse calls
* dense fall-throughs
* logical step
* sequence/block statistics
* failure state
* summary state

cannot leak between independent sampling runs.

The displaced attention backend remains preserved as intended.

## Regression coverage

Added dependency-free tests for the wrapper and sampler-state contracts.

Coverage includes:

* SLA correctly invoking a downstream wrapper before the original model
* preservation of `minimax_payload`
* compatibility with the existing non-callable executor shim
* multiple Spectrum-like runs where only a subset of sampler steps performs an actual NFE
* a 19-step generation pattern with 10 actual evaluations
* a subsequent 19-step pattern with 12 actual evaluations
* repeated 3-step refinement passes with 2 actual evaluations
* `dense_last_steps` following the real sampler position even when intermediate NFEs are skipped

A GitHub Actions workflow was also added to compile the relevant code and run these regression tests on Python:

* 3.10
* 3.11
* 3.12
* 3.13

## Scope

This does not change the SLA attention kernel, block selection, sparsity calculation, audio-prefix protection, or model weights.

The change is limited to wrapper composition and sampler/run-state bookkeeping so SLA behaves correctly when combined with other ComfyUI model wrappers.
