### PR TITLE
Reduce H3 SLA stabilization state and narrow audio protection

### DIFF
--- a/ComfyUI-H3-SLA-Attention/sla/block_map.py
+++ b/ComfyUI-H3-SLA-Attention/sla/block_map.py
@@ -88,10 +88,51 @@ def mean_pool(x, BLK):
 # still wins, big enough to kill a near-tie flip between steps that isn't
 # telling you anything real.
 _STICKY_BONUS_FRAC = 0.05
+# Only selections close to the top-k cutoff can realistically flip on the next
+# step.  Keeping the complete LUT for all 50 H3 layers makes stabilization
+# state scale as O(NQ * topk) and can retain several GB of VRAM at 768p.  Eight
+# boundary entries per query row preserve the intended hysteresis while making
+# the retained state O(NQ) with a small constant.
+_STICKY_HISTORY_WIDTH = 8
+
+
+def get_protected_block_ranges(protect_upto, protect_ranges, BLKK, NK):
+    """Return merged half-open key-block ranges that must always be selected.
+
+    ``protect_upto`` keeps compatibility with the original prefix-only API.
+    ``protect_ranges`` permits precise token spans, notably H3's audio segment,
+    without force-selecting intervening text or reference-image tokens.
+    """
+    token_ranges = []
+    if protect_upto > 0:
+        token_ranges.append((0, int(protect_upto)))
+    for item in protect_ranges or ():
+        try:
+            start, stop = int(item[0]), int(item[1])
+        except (IndexError, TypeError, ValueError):
+            continue
+        if stop <= start:
+            continue
+        token_ranges.append((max(0, start), max(0, stop)))
+
+    block_ranges = []
+    for start, stop in token_ranges:
+        first = min(NK, start // BLKK)
+        last = min(NK, (stop + BLKK - 1) // BLKK)
+        if first < last:
+            block_ranges.append((first, last))
+
+    merged = []
+    for first, last in sorted(block_ranges):
+        if merged and first <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], last))
+        else:
+            merged.append((first, last))
+    return tuple(merged)
 
 
 def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
-                  prev_lut=None):
+                  prev_lut=None, protect_ranges=None, return_history=False):
     """Return ``(lut, topk)``: the key blocks each query block should attend to.
 
     ``q``/``k`` are ``(B, L, H, D)`` contiguous. ``lut`` comes back as
@@ -105,15 +146,24 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     are added on top of the top-k budget rather than displacing video, so video
     coverage is unchanged and the extra cost is the prefix itself (~7%).
 
-    ``prev_lut``, when given the previous call's ``lut`` for this same layer,
-    nudges those blocks' scores up before top-k -- pure per-step top-k has no
-    memory, so on a near-tie between two similarly-scored blocks the winner
-    can flip step to step for no reason tied to actual content, and on fast
-    motion that shows up as a faint double-exposure rather than one clean
-    pick. The nudge only breaks a close call; a block that's actually a
-    better fit this step still wins. Silently ignored if its shape doesn't
-    match this call's (e.g. right after a dense step, or the first sparse
-    call of a run).
+    ``protect_ranges`` provides the same guarantee for specific half-open token
+    spans. H3 uses it to protect only audio instead of treating the complete
+    ``[text | cond/ref | audio]`` prefix as audio. It is merged with
+    ``protect_upto`` when both are supplied.
+
+    ``prev_lut``, when given the previous call's bounded history for this same
+    layer, nudges those blocks' scores up before top-k -- pure per-step top-k
+    has no memory, so on a near-tie between two similarly-scored blocks the
+    winner can flip step to step for no reason tied to actual content, and on
+    fast motion that shows up as a faint double-exposure rather than one clean
+    pick. The nudge only breaks a close call; a block that's actually a better
+    fit this step still wins. Silently ignored if its shape doesn't match this
+    call's (e.g. after a resolution change or the first sparse call of a run).
+
+    With ``return_history=True``, also return a compact LUT containing only the
+    selected blocks closest to the top-k cutoff. Strong selections do not need
+    a sticky bonus; retaining them was the source of multi-GB stabilization
+    state at long H3 sequence lengths.
     """
     pooled_q = mean_pool(q, BLKQ)
     # Smooth-k (SageAttention's trick), folded in rather than materialised.
@@ -141,15 +191,34 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     # FIX vs upstream: keep at least one key block.
     topk = max(1, min(NK, int(topk_ratio * NK)))
 
-    n_pinned = 0
-    if protect_upto > 0:
-        n_pinned = min((int(protect_upto) + BLKK - 1) // BLKK, NK)
-        # Ranking them above everything else is what pins them; widening topk by
-        # the same amount is what stops them evicting the blocks top-k chose.
-        if n_pinned > 0:
-            pooled_score[..., :n_pinned] = float("inf")
-            topk = min(NK, topk + n_pinned)
+    protected_blocks = get_protected_block_ranges(
+        protect_upto, protect_ranges, BLKK, NK
+    )
+    n_pinned = sum(last - first for first, last in protected_blocks)
+    # Ranking protected blocks above everything else is what pins them;
+    # widening topk by the same amount stops them evicting the blocks that the
+    # ordinary top-k selection would otherwise keep.
+    for first, last in protected_blocks:
+        pooled_score[..., first:last] = float("inf")
+    if n_pinned > 0:
+        topk = min(NK, topk + n_pinned)
 
-    lut = torch.topk(pooled_score, topk, dim=-1, sorted=False).indices
+    selected = torch.topk(pooled_score, topk, dim=-1, sorted=False)
+    lut = selected.indices
+    lut_i32 = lut.to(torch.int32).contiguous()
 
-    return lut.to(torch.int32).contiguous(), topk
+    if not return_history:
+        return lut_i32, topk
+
+    history_width = min(_STICKY_HISTORY_WIDTH, topk)
+    if history_width == topk:
+        history = lut
+    else:
+        # The lowest scores inside the selected set sit at the top-k boundary
+        # and are the only entries likely to flip membership on the next step.
+        boundary_pos = torch.topk(
+            selected.values, history_width, dim=-1, largest=False, sorted=False
+        ).indices
+        history = torch.gather(lut, -1, boundary_pos)
+
+    return lut_i32, topk, history.to(torch.int32).contiguous()

--- a/ComfyUI-H3-SLA-Attention/sla/patch.py
+++ b/ComfyUI-H3-SLA-Attention/sla/patch.py
@@ -21,7 +21,7 @@ import logging
 
 import torch
 
-from .block_map import get_block_map
+from .block_map import get_block_map, get_protected_block_ranges
 from .kernel import block_sparse_attention
 
 log = logging.getLogger("H3Utils")
@@ -231,7 +231,7 @@ def _new_state():
         "failed": None,    # first kernel failure, if any
         "fp16_saved": None,     # (fp16, bf16) matmul reduction flags to restore
         "call_idx": 0,       # this step's call count, for stabilize_motion
-        "prev_lut": {},      # call_idx -> last sparse lut, for stabilize_motion
+        "prev_lut": {},      # call_idx -> bounded boundary LUT for motion stability
     }
 
 
@@ -248,6 +248,10 @@ def _reset_run_state(state):
     state["blocks"] = 0
     state["pinned"] = 0
     state["failed"] = None
+    state["call_idx"] = 0
+    # The history is generation-local.  Besides preventing one video's block
+    # choices from biasing the next, clearing it releases retained GPU tensors.
+    state["prev_lut"].clear()
 
 
 def _summarise(state, sparsity, blkq, blkk):
@@ -285,13 +289,12 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
     is set globally; the sparse path is unaffected either way, since it
     never calls ``func`` at all.
 
-    ``stabilize_motion`` carries each layer's previously-selected key blocks
-    into ``get_block_map`` as a tie-breaker (see block_map.py); it costs one
-    small dict lookup and store per call, nothing else. ``state["call_idx"]``
-    is the layer identity this relies on -- it counts calls within the
-    current step, reset to 0 by the wrapper at the top of every step, and it
-    works because the model graph is static: the Nth attention call happens
-    in the same layer every step.
+    ``stabilize_motion`` carries a bounded set of each layer's near-cutoff key
+    blocks into ``get_block_map`` as a tie-breaker (see block_map.py).
+    ``state["call_idx"]`` is the layer identity this relies on -- it counts
+    calls within the current step, reset to 0 by the wrapper at the top of
+    every step, and it works because the model graph is static: the Nth
+    attention call happens in the same layer every step.
     """
     topk_ratio = 1.0 - sparsity_ratio
 
@@ -337,12 +340,16 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
             if not qb.is_contiguous():
                 qb, kb, vb = qb.contiguous(), kb.contiguous(), vb.contiguous()
 
-            # Pin the [text | cond | audio] prefix into every query's
-            # selection. Audio is ~1% of the packed sequence, so plain top-k
-            # routinely drops all of it and the soundtrack degrades while the
-            # video stays fine. 0 when the layout is unavailable, which simply
-            # disables the protection rather than guessing.
-            prefix = int(to.get("_h3sla_prefix", 0) or 0) if protect_audio else 0
+            # Pin audio into every query's selection. New wrappers provide its
+            # precise token ranges so reference images are not accidentally
+            # force-selected too. The prefix value is a compatibility fallback
+            # for transformer_options produced by older wrappers.
+            protected_ranges = None
+            prefix = 0
+            if protect_audio:
+                protected_ranges = to.get("_h3sla_protected_ranges")
+                if protected_ranges is None:
+                    prefix = int(to.get("_h3sla_prefix", 0) or 0)
             if prefix >= S:
                 prefix = 0
 
@@ -350,17 +357,31 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
             state["call_idx"] = call_idx + 1
             prev_lut = state["prev_lut"].get(call_idx) if stabilize_motion else None
 
-            lut, topk = get_block_map(qb, kb, topk_ratio, blkq, blkk,
-                                      protect_upto=prefix, prev_lut=prev_lut)
             if stabilize_motion:
-                state["prev_lut"][call_idx] = lut
+                lut, topk, history_lut = get_block_map(
+                    qb, kb, topk_ratio, blkq, blkk,
+                    protect_upto=prefix, prev_lut=prev_lut,
+                    protect_ranges=protected_ranges,
+                    return_history=True,
+                )
+                state["prev_lut"][call_idx] = history_lut
+            else:
+                lut, topk = get_block_map(
+                    qb, kb, topk_ratio, blkq, blkk,
+                    protect_upto=prefix,
+                    protect_ranges=protected_ranges,
+                )
             out = block_sparse_attention(qb, kb, vb, lut, topk, blkq, blkk)
 
             state["calls"] += 1
             state["seq"] = S
             state["kept"] = topk
             state["blocks"] = (S + blkk - 1) // blkk
-            state["pinned"] = (prefix + blkk - 1) // blkk
+            state["pinned"] = sum(
+                last - first for first, last in get_protected_block_ranges(
+                    prefix, protected_ranges, blkk, state["blocks"]
+                )
+            )
 
             # [1, S, H, D] -> what the caller expects
             if skip_output_reshape:
@@ -545,17 +566,22 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
             _set_fp16_accum(False)
 
         # PackedLayout.segments is [(start, stop, kind), ...] over
-        # [text | cond/ref | audio | video]; the video start is therefore the
-        # length of everything that must stay exactly attended. It lives on the
-        # payload, which never reaches the attention call site, so the wrapper
-        # is the only place it can be picked up.
+        # [text | cond/ref | audio | video]. Preserve the historical prefix for
+        # compatibility and also pass precise audio spans so protect_audio no
+        # longer force-selects high-resolution reference-image tokens.
         prefix = 0
+        audio_ranges = []
         layout = minimax_payload.get("layout") if minimax_payload else None
         for seg in getattr(layout, "segments", ()) or ():
-            if len(seg) == 3 and seg[2] == "video":
-                prefix = int(seg[0])
-                break
+            if len(seg) != 3:
+                continue
+            start, stop, kind = seg
+            if kind == "audio":
+                audio_ranges.append((int(start), int(stop)))
+            elif kind == "video" and prefix == 0:
+                prefix = int(start)
         to["_h3sla_prefix"] = prefix
+        to["_h3sla_protected_ranges"] = tuple(audio_ranges)
 
         step0 = state["step"] - 1  # 0-based, for dense_steps membership
         to["_h3sla_dense"] = bool(
@@ -589,6 +615,9 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
                 if orig_bf16 is not None:
                     backend.allow_bf16_reduced_precision_reduction = orig_bf16
                 state["fp16_saved"] = None
+            # Do not retain GPU-resident motion history while ComfyUI is idle,
+            # and never carry one video's selections into the next video.
+            state["prev_lut"].clear()
         return out
 
     return wrapper

--- a/ComfyUI-H3-SLA-Attention/sla_node.py
+++ b/ComfyUI-H3-SLA-Attention/sla_node.py
@@ -111,13 +111,14 @@ class H3SLAAttention(io.ComfyNode):
                     label_on="protect", label_off="uniform (lightx2v parity)",
                     optional=True,
                     tooltip=(
-                        "Always attend the [text | cond | audio] prefix, "
-                        "whatever top-k picks. Audio is about 1% of the packed "
-                        "sequence -- 19 key blocks of 1794 at 768p/15s -- so "
-                        "plain top-k regularly drops all of it and the "
-                        "soundtrack degrades while the video still looks fine. "
-                        "Costs roughly 7%. Turn off only to reproduce "
-                        "lightx2v's uniform selection exactly.")),
+                        "Always attend blocks overlapping actual audio "
+                        "segments, whatever top-k picks. Reference-image and "
+                        "text/conditioning blocks are not force-selected. "
+                        "Audio is about 1% of the packed sequence -- 19 key "
+                        "blocks of 1794 at 768p/15s -- so plain top-k can drop "
+                        "all of it while the video still looks fine. Turn off "
+                        "only to reproduce lightx2v's uniform selection "
+                        "exactly.")),
                 io.Boolean.Input("enabled", default=True,
                     label_on="sparse", label_off="dense (bypass)",
                     optional=True,
@@ -184,9 +185,10 @@ class H3SLAAttention(io.ComfyNode):
                         "Bias each layer's block selection toward what it "
                         "picked last step, so a near-tie between two blocks "
                         "doesn't flip for no reason and show up as a faint "
-                        "double-exposure on fast motion. Costs essentially "
-                        "nothing, but it's a fix for that one specific "
-                        "symptom, not a general quality dial ")),
+                        "double-exposure on fast motion. Keeps a bounded set "
+                        "of near-cutoff block choices per layer; it is a fix "
+                        "for that one specific symptom, not a general quality "
+                        "dial.")),
             ],
             outputs=[io.Model.Output()],
         )

--- a/ComfyUI-H3-SLA-Attention/tests/test_sla.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_sla.py
@@ -239,6 +239,24 @@ class StepWrapper(unittest.TestCase):
 @unittest.skipUnless(CUDA, "needs CUDA and triton")
 class Kernel(unittest.TestCase):
 
+    def test_motion_history_is_bounded_and_selected(self):
+        """Motion stabilization must not retain the complete per-layer LUT."""
+        from h3u.sla.block_map import get_block_map
+
+        S = 4096
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        lut, topk, history = get_block_map(
+            q, k, 0.15, 64, 64, return_history=True
+        )
+
+        self.assertEqual(history.shape[:-1], lut.shape[:-1])
+        self.assertLessEqual(history.shape[-1], 8)
+        self.assertLess(history.shape[-1], topk)
+        is_selected = (history.unsqueeze(-1) == lut.unsqueeze(-2)).any(dim=-1)
+        self.assertTrue(is_selected.all())
+
     def test_zero_sparsity_matches_dense_attention(self):
         """With every block kept, the sparse kernel is just attention."""
         from h3u.sla.block_map import get_block_map
@@ -295,6 +313,31 @@ class Kernel(unittest.TestCase):
         got = lut.long().sort(dim=-1).values[..., :n_pinned]
         want = torch.arange(n_pinned, device=lut.device)
         self.assertTrue(torch.equal(got, want.expand_as(got)))
+
+    def test_audio_range_does_not_pin_conditioning_prefix(self):
+        """Protect audio precisely instead of force-selecting refs before it."""
+        from h3u.sla.block_map import get_block_map
+
+        S = 16384
+        audio_start, audio_stop = 4096, 6144
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        lut, _ = get_block_map(
+            q, k, 0.05, 128, 64,
+            protect_ranges=((audio_start, audio_stop),),
+        )
+
+        first_audio = audio_start // 64
+        last_audio = audio_stop // 64
+        audio_blocks = torch.arange(first_audio, last_audio, device=lut.device)
+        has_audio = (lut.unsqueeze(-1).long() == audio_blocks).any(dim=-2)
+        self.assertTrue(has_audio.all(), "an audio block was not protected")
+
+        # There are more conditioning-prefix blocks than non-audio slots in
+        # this deliberately small top-k, so the full prefix cannot be pinned.
+        prefix_coverage = (lut.long() < first_audio).sum(dim=-1)
+        self.assertLess(prefix_coverage.max().item(), first_audio)
 
     def test_pinning_selects_the_same_blocks_at_zero_sparsity(self):
         """Pinning must decide *which* blocks, never alter their values.

--- a/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
@@ -40,6 +40,7 @@ def _load_patch_module():
     block_map.get_block_map = lambda *args, **kwargs: (_ for _ in ()).throw(
         AssertionError("attention routing is outside this wrapper-chain test")
     )
+    block_map.get_protected_block_ranges = lambda *args, **kwargs: ()
     sys.modules[block_map.__name__] = block_map
 
     kernel = types.ModuleType(f"{_PACKAGE}.sla.kernel")
@@ -83,6 +84,36 @@ class WrapperExecutor:
 
 
 class WrapperChainRegression(unittest.TestCase):
+    def test_run_reset_clears_motion_history(self):
+        """GPU LUTs and choices from one video must not survive its run."""
+
+        state = sla_patch._new_state()
+        marker = object()
+        state["prev_lut"][0] = marker
+        state["call_idx"] = 17
+
+        sla_patch._reset_run_state(state)
+
+        self.assertEqual(state["prev_lut"], {})
+        self.assertEqual(state["call_idx"], 0)
+
+    def test_end_of_run_releases_motion_history(self):
+        """Release history immediately rather than waiting for another run."""
+
+        state = sla_patch._new_state()
+        state["prev_lut"][0] = object()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 0)
+        executor = WrapperExecutor(lambda *a, **k: None, [sla_wrapper])
+
+        executor.execute(
+            object(),
+            object(),
+            object(),
+            transformer_options={"sample_sigmas": [1.0, 0.0]},
+        )
+
+        self.assertEqual(state["prev_lut"], {})
+
     def test_sla_advances_to_downstream_wrapper_before_original(self):
         events = []
         state = sla_patch._new_state()
@@ -134,6 +165,35 @@ class WrapperChainRegression(unittest.TestCase):
         )
 
         self.assertIs(seen["minimax_payload"], payload)
+
+    def test_audio_range_is_read_without_pinning_reference_segments(self):
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 0)
+        seen = {}
+
+        class Layout:
+            segments = [
+                (0, 512, "text"),
+                (512, 8192, "cond"),
+                (8192, 10192, "audio"),
+                (10192, 120000, "video"),
+            ]
+
+        def downstream(executor, *args, **kwargs):
+            seen.update(kwargs["transformer_options"])
+            return executor(*args, **kwargs)
+
+        executor = WrapperExecutor(
+            lambda *a, **k: None, [sla_wrapper, downstream]
+        )
+        executor.execute(
+            object(), object(), object(),
+            transformer_options={"sample_sigmas": [1.0, 0.0]},
+            minimax_payload={"layout": Layout()},
+        )
+
+        self.assertEqual(seen["_h3sla_protected_ranges"], ((8192, 10192),))
+        self.assertEqual(seen["_h3sla_prefix"], 10192)
 
     def test_spectrum_forecasts_do_not_merge_sla_run_state(self):
         """Skipped NFEs must not make SLA count across independent sampler runs."""


### PR DESCRIPTION
## Summary

- retain only eight near-cutoff block selections per query row for motion stabilization instead of retaining each complete sparse LUT
- clear motion history at generation boundaries and after the final model call
- keep stabilize_motion enabled by default
- protect only blocks overlapping actual audio layout segments instead of the complete text, conditioning, reference, and audio prefix
- preserve the prefix API as a compatibility fallback

## Motivation

High-resolution H3 generations, especially with reference images, can slow down substantially when stabilize_motion is enabled. Complete per-layer LUT history scales with the selected top-k width. Reference-image tokens also enlarged protect_audio because the original implementation pinned every token before video.

The sparse kernel still receives the complete current LUT. Only the history carried into the next step is bounded to selections nearest the top-k cutoff, which are the entries most likely to flip.

## Testing

- python -m unittest discover -s ComfyUI-H3-SLA-Attention/tests -v
- 28 tests discovered; dependency-free tests pass
- 20 Torch, CUDA, or Triton-dependent tests are skipped in the development environment
- added CUDA coverage for bounded history and precise audio-range protection

## Validation requested

This is a draft because the new CUDA tests and real H3 quality/performance comparisons still need to run on an H3-capable GPU. In particular, the boundary-history width should be checked for motion quality and the audio-range change should be checked with reference-image workflows.