### PR TITLE
Protect H3 audio and add audited visual-reference modes in SLA

### DIFF
--- a/ComfyUI-H3-SLA-Attention/sla/block_map.py
+++ b/ComfyUI-H3-SLA-Attention/sla/block_map.py
@@ -27,6 +27,8 @@ Three changes against upstream, marked FIX:
 
 from __future__ import annotations
 
+import math
+
 import torch
 import triton
 import triton.language as tl
@@ -97,8 +99,83 @@ _STICKY_BONUS_FRAC = 0.05
 _STICKY_HISTORY_WIDTH = 8
 
 
+def get_protected_block_ranges(protect_upto, protect_ranges, BLKK, NK):
+    """Return merged half-open key-block ranges that must always be selected.
+
+    ``protect_upto`` keeps compatibility with the original prefix-only API.
+    ``protect_ranges`` permits precise token spans, notably H3's audio segment,
+    without force-selecting intervening text or reference-image tokens.
+    """
+    token_ranges = []
+    if protect_upto > 0:
+        token_ranges.append((0, int(protect_upto)))
+    for item in protect_ranges or ():
+        try:
+            start, stop = int(item[0]), int(item[1])
+        except (IndexError, TypeError, ValueError):
+            continue
+        if stop <= start:
+            continue
+        token_ranges.append((max(0, start), max(0, stop)))
+
+    block_ranges = []
+    for start, stop in token_ranges:
+        first = min(NK, start // BLKK)
+        last = min(NK, (stop + BLKK - 1) // BLKK)
+        if first < last:
+            block_ranges.append((first, last))
+
+    merged = []
+    for first, last in sorted(block_ranges):
+        if merged and first <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], last))
+        else:
+            merged.append((first, last))
+    return tuple(merged)
+
+
+def get_reference_quota_block_ranges(reference_ranges, protect_upto,
+                                     protected_ranges, BLKK, NK):
+    """Return reference block ranges excluding blocks already fully pinned.
+
+    Token spans are rounded out to key-block boundaries. Any overlap with the
+    language/audio protection is subtracted so the optional reference quota
+    never pays for, or counts, a block that is already guaranteed.
+    """
+    references = get_protected_block_ranges(0, reference_ranges, BLKK, NK)
+    protected = get_protected_block_ranges(
+        protect_upto, protected_ranges, BLKK, NK
+    )
+    available = []
+    for first, last in references:
+        pieces = [(first, last)]
+        for protected_first, protected_last in protected:
+            next_pieces = []
+            for piece_first, piece_last in pieces:
+                if protected_last <= piece_first or protected_first >= piece_last:
+                    next_pieces.append((piece_first, piece_last))
+                    continue
+                if piece_first < protected_first:
+                    next_pieces.append((piece_first, protected_first))
+                if protected_last < piece_last:
+                    next_pieces.append((protected_last, piece_last))
+            pieces = next_pieces
+        available.extend(pieces)
+    return tuple(available)
+
+
+def get_reference_quota_keep_count(block_count, reference_sparsity):
+    """Translate reference sparsity into a guaranteed number of key blocks."""
+    if reference_sparsity is None or block_count <= 0:
+        return 0
+    sparsity = max(0.0, min(0.99, float(reference_sparsity)))
+    return max(1, min(block_count, math.ceil((1.0 - sparsity) * block_count)))
+
+
 def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
-                  prev_lut=None, return_history=False):
+                  prev_lut=None, protect_ranges=None, return_history=False,
+                  stabilize_query_from=0, reference_ranges=None,
+                  reference_sparsity=None):
     """Return ``(lut, topk)``: the key blocks each query block should attend to.
 
     ``q``/``k`` are ``(B, L, H, D)`` contiguous. ``lut`` comes back as
@@ -112,6 +189,17 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     are added on top of the top-k budget rather than displacing video, so video
     coverage is unchanged and the extra cost is the prefix itself (~7%).
 
+    ``protect_ranges`` provides the same guarantee for specific half-open token
+    spans. H3 uses it for language and audio while excluding large visual-
+    reference spans. It is merged with ``protect_upto`` when both are supplied.
+
+    ``reference_ranges`` plus a non-None ``reference_sparsity`` adds a second,
+    segment-local selection tier for visual conditioning. For example, 0.80
+    guarantees the best-scoring 20% of each reference block range per query,
+    while 0.0 guarantees all of it. ``None`` disables the quota. This is
+    intentionally additive so reference safety never evicts video blocks that
+    the unmodified sparse route would have selected.
+
     ``prev_lut``, when given the previous call's ``lut`` for this same layer,
     nudges those blocks' scores up before top-k -- pure per-step top-k has no
     memory, so on a near-tie between two similarly-scored blocks the winner
@@ -120,7 +208,8 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     pick. The nudge only breaks a close call; a block that's actually a
     better fit this step still wins. Silently ignored if its shape doesn't
     match this call's (e.g. right after a dense step, or the first sparse
-    call of a run).
+    call of a run). ``stabilize_query_from`` is a token offset; query blocks
+    before the target-video region are neither retained nor biased.
     """
     pooled_q = mean_pool(q, BLKQ)
     # Smooth-k (SageAttention's trick), folded in rather than materialised.
@@ -135,27 +224,55 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
 
     pooled_score = pooled_q @ pooled_k.transpose(-1, -2)      # (B, H, NQ, NK)
 
+    NQ = pooled_score.shape[-2]
+    sticky_q_start = min(
+        NQ,
+        (max(0, int(stabilize_query_from)) + BLKQ - 1) // BLKQ,
+    )
+    sticky_score = pooled_score[..., sticky_q_start:, :]
     if (
         prev_lut is not None
-        and prev_lut.shape[:3] == pooled_score.shape[:3]
+        and prev_lut.shape[:3] == sticky_score.shape[:3]
         and prev_lut.shape[-1] <= pooled_score.shape[-1]
     ):
-        row_scale = pooled_score.detach().abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+        row_scale = sticky_score.detach().abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
         bonus = (row_scale * _STICKY_BONUS_FRAC).expand(*prev_lut.shape)
-        pooled_score.scatter_add_(-1, prev_lut.long(), bonus)
+        sticky_score.scatter_add_(-1, prev_lut.long(), bonus)
 
     NK = pooled_score.shape[-1]
     # FIX vs upstream: keep at least one key block.
     topk = max(1, min(NK, int(topk_ratio * NK)))
 
-    n_pinned = 0
-    if protect_upto > 0:
-        n_pinned = min((int(protect_upto) + BLKK - 1) // BLKK, NK)
-        # Ranking them above everything else is what pins them; widening topk by
-        # the same amount is what stops them evicting the blocks top-k chose.
-        if n_pinned > 0:
-            pooled_score[..., :n_pinned] = float("inf")
-            topk = min(NK, topk + n_pinned)
+    protected_blocks = get_protected_block_ranges(
+        protect_upto, protect_ranges, BLKK, NK
+    )
+    n_pinned = sum(last - first for first, last in protected_blocks)
+    n_reference_quota = 0
+    if reference_sparsity is not None:
+        reference_sparsity = float(reference_sparsity)
+        reference_blocks = get_reference_quota_block_ranges(
+            reference_ranges, protect_upto, protect_ranges, BLKK, NK
+        )
+        for first, last in reference_blocks:
+            block_count = last - first
+            keep = get_reference_quota_keep_count(
+                block_count, reference_sparsity
+            )
+            if keep <= 0:
+                continue
+            selected_reference = torch.topk(
+                pooled_score[..., first:last], keep, dim=-1, sorted=False
+            ).indices + first
+            pooled_score.scatter_(-1, selected_reference, float("inf"))
+            n_reference_quota += keep
+
+    # Ranking protected blocks above everything else is what pins them;
+    # widening topk by the same amount stops them evicting the blocks that the
+    # ordinary top-k selection would otherwise keep.
+    for first, last in protected_blocks:
+        pooled_score[..., first:last] = float("inf")
+    if n_pinned > 0 or n_reference_quota > 0:
+        topk = min(NK, topk + n_pinned + n_reference_quota)
 
     selected = torch.topk(pooled_score, topk, dim=-1, sorted=False)
     lut = selected.indices
@@ -168,13 +285,15 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     # entries nearest the cutoff -- the only ones that can plausibly flip.
     # Strong selections do not need a sticky bonus, so dropping them from
     # the retained history costs nothing but the VRAM they were sitting on.
+    history_indices = lut[..., sticky_q_start:, :]
+    history_values = selected.values[..., sticky_q_start:, :]
     history_width = min(_STICKY_HISTORY_WIDTH, topk)
     if history_width == topk:
-        history = lut
+        history = history_indices
     else:
         boundary_pos = torch.topk(
-            selected.values, history_width, dim=-1, largest=False, sorted=False
+            history_values, history_width, dim=-1, largest=False, sorted=False
         ).indices
-        history = torch.gather(lut, -1, boundary_pos)
+        history = torch.gather(history_indices, -1, boundary_pos)
 
     return lut_i32, topk, history.to(torch.int32).contiguous()

--- a/ComfyUI-H3-SLA-Attention/sla/patch.py
+++ b/ComfyUI-H3-SLA-Attention/sla/patch.py
@@ -21,7 +21,7 @@ import logging
 
 import torch
 
-from .block_map import get_block_map
+from .block_map import get_block_map, get_protected_block_ranges
 from .kernel import block_sparse_attention
 
 log = logging.getLogger("H3Utils")
@@ -279,7 +279,8 @@ def _summarise(state, sparsity, blkq, blkk):
 
 
 def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
-                   protect_audio=True, dense_fn=None, stabilize_motion=False):
+                   protect_audio=True, dense_fn=None, stabilize_motion=False,
+                   reference_sparsity=None):
     """``dense_fn``, when not None, is a specific backend (e.g. always
     ``attention_pytorch``) that every dense fall-through uses instead of
     ``func``. Without it, ``func`` is whatever ``optimized_attention``
@@ -290,9 +291,9 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
     is set globally; the sparse path is unaffected either way, since it
     never calls ``func`` at all.
 
-    ``stabilize_motion`` carries each layer's previously-selected key blocks
-    into ``get_block_map`` as a tie-breaker (see block_map.py); it costs one
-    small dict lookup and store per call, nothing else. ``state["call_idx"]``
+    ``stabilize_motion`` carries each layer's near-cutoff target-video choices
+    into ``get_block_map`` as a tie-breaker (see block_map.py). Text and audio
+    query routing remains step-local. ``state["call_idx"]``
     is the layer identity this relies on -- it counts calls within the
     current step, reset to 0 by the wrapper at the top of every step, and it
     works because the model graph is static: the Nth attention call happens
@@ -342,14 +343,21 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
             if not qb.is_contiguous():
                 qb, kb, vb = qb.contiguous(), kb.contiguous(), vb.contiguous()
 
-            # Pin the [text | cond | audio] prefix into every query's
-            # selection. Audio is ~1% of the packed sequence, so plain top-k
-            # routinely drops all of it and the soundtrack degrades while the
-            # video stays fine. 0 when the layout is unavailable, which simply
-            # disables the protection rather than guessing.
-            prefix = int(to.get("_h3sla_prefix", 0) or 0) if protect_audio else 0
+            # Audio/language protection is deliberately all-or-nothing: testing
+            # found partial audio quotas unstable for negligible speed benefit.
+            # Visual references retain their independent sparse quota.
+            protected_ranges = None
+            prefix = 0
+            if protect_audio:
+                protected_ranges = to.get("_h3sla_protected_ranges")
+                if protected_ranges is None:
+                    prefix = int(to.get("_h3sla_prefix", 0) or 0)
             if prefix >= S:
                 prefix = 0
+            stabilize_query_from = int(
+                to.get("_h3sla_stabilize_query_from", 0) or 0
+            )
+            reference_ranges = to.get("_h3sla_reference_ranges")
 
             call_idx = state["call_idx"]
             state["call_idx"] = call_idx + 1
@@ -358,22 +366,35 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
             if stabilize_motion:
                 lut, topk, history = get_block_map(
                     qb, kb, topk_ratio, blkq, blkk,
-                    protect_upto=prefix, prev_lut=prev_lut, return_history=True,
+                    protect_upto=prefix, prev_lut=prev_lut,
+                    protect_ranges=protected_ranges, return_history=True,
+                    stabilize_query_from=stabilize_query_from,
+                    reference_ranges=reference_ranges,
+                    reference_sparsity=reference_sparsity,
                 )
                 # Only the bounded boundary slice is retained -- see
                 # block_map.py. Storing the full lut here is what made this
                 # grow to several GB per run at 768p with stabilize_motion on.
                 state["prev_lut"][call_idx] = history
             else:
-                lut, topk = get_block_map(qb, kb, topk_ratio, blkq, blkk,
-                                          protect_upto=prefix, prev_lut=prev_lut)
+                lut, topk = get_block_map(
+                    qb, kb, topk_ratio, blkq, blkk,
+                    protect_upto=prefix, prev_lut=prev_lut,
+                    protect_ranges=protected_ranges,
+                    reference_ranges=reference_ranges,
+                    reference_sparsity=reference_sparsity,
+                )
             out = block_sparse_attention(qb, kb, vb, lut, topk, blkq, blkk)
 
             state["calls"] += 1
             state["seq"] = S
             state["kept"] = topk
             state["blocks"] = (S + blkk - 1) // blkk
-            state["pinned"] = (prefix + blkk - 1) // blkk
+            state["pinned"] = sum(
+                last - first for first, last in get_protected_block_ranges(
+                    prefix, protected_ranges, blkk, state["blocks"]
+                )
+            )
 
             # [1, S, H, D] -> what the caller expects
             if skip_output_reshape:
@@ -411,6 +432,77 @@ def _sequence_scalar(value):
             return None
         return float(value[0])
     return None
+
+
+def _tagged_text_ranges(start, stop, text_token_tags, wanted_tag, fallback):
+    """Return contiguous spans for one H3 presentation-token tag."""
+    if text_token_tags is None:
+        return fallback
+    try:
+        if hasattr(text_token_tags, "reshape"):
+            tags = text_token_tags.reshape(-1).tolist()
+        else:
+            tags = list(text_token_tags)
+    except (AttributeError, TypeError, ValueError):
+        return fallback
+
+    expected = int(stop) - int(start)
+    if len(tags) != expected:
+        return fallback
+    try:
+        tags = [int(tag) for tag in tags]
+    except (TypeError, ValueError):
+        return fallback
+
+    ranges = []
+    run_start = None
+    for offset, tag in enumerate(tags):
+        is_wanted = tag == wanted_tag
+        if is_wanted and run_start is None:
+            run_start = offset
+        elif not is_wanted and run_start is not None:
+            ranges.append((int(start) + run_start, int(start) + offset))
+            run_start = None
+    if run_start is not None:
+        ranges.append((int(start) + run_start, int(stop)))
+    return tuple(ranges)
+
+
+def _language_token_ranges(start, stop, text_token_tags):
+    """Return language spans, safely falling back to the whole text segment."""
+    return _tagged_text_ranges(
+        start, stop, text_token_tags, 1, ((int(start), int(stop)),)
+    )
+
+
+def _vision_token_ranges(start, stop, text_token_tags):
+    """Return Qwen vision spans; missing tags mean no optional reference quota."""
+    return _tagged_text_ranges(start, stop, text_token_tags, 0, ())
+
+
+REFERENCE_LIGHT_SPARSITY = 0.85
+
+
+def _resolve_reference_sparsity(reference_protection):
+    """Resolve True/Light/Off; old Manual workflows migrate to fixed Light."""
+    if reference_protection is True:
+        mode = "true"
+    elif reference_protection is False or reference_protection is None:
+        mode = "off"
+    else:
+        mode = str(reference_protection).strip().lower()
+    if mode == "true":
+        return mode, 0.0
+    if mode in ("light", "manual"):
+        return "light", REFERENCE_LIGHT_SPARSITY
+    return "off", None
+
+
+def _resolve_audio_protection(protect_audio):
+    """Resolve the Boolean switch and safely read workflows saved during PR #1."""
+    if isinstance(protect_audio, str):
+        return protect_audio.strip().lower() not in ("off", "false", "0", "no")
+    return bool(protect_audio)
 
 
 def _resolve_sampler_step(transformer_options):
@@ -519,7 +611,8 @@ def _set_fp16_accum(enabled):
 
 
 def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
-                  dense_steps=frozenset(), disable_fp16_accum=False):
+                  dense_steps=frozenset(), disable_fp16_accum=False,
+                  reference_quota_enabled=False):
     """DIFFUSION_MODEL wrapper: per-step state, and the end-of-run summary.
 
     Registered once and then reused -- ComfyUI caches node outputs, so this
@@ -557,18 +650,42 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
             # reduced-precision reduction path while this model is patched.
             _set_fp16_accum(False)
 
-        # PackedLayout.segments is [(start, stop, kind), ...] over
-        # [text | cond/ref | audio | video]; the video start is therefore the
-        # length of everything that must stay exactly attended. It lives on the
-        # payload, which never reaches the attention call site, so the wrapper
-        # is the only place it can be picked up.
+        # Preserve the historical prefix for compatibility, but current H3
+        # payloads let us protect language/audio spans precisely while leaving
+        # Qwen vision and visual conditioning/reference rows sparse. Motion
+        # hysteresis begins only at the target-video segment.
         prefix = 0
+        protected_ranges = []
+        reference_ranges = []
         layout = minimax_payload.get("layout") if minimax_payload else None
+        text_token_tags = (
+            minimax_payload.get("text_token_tags") if minimax_payload else None
+        )
         for seg in getattr(layout, "segments", ()) or ():
-            if len(seg) == 3 and seg[2] == "video":
-                prefix = int(seg[0])
-                break
+            if len(seg) != 3:
+                continue
+            start, stop, kind = seg
+            if kind == "text":
+                protected_ranges.extend(
+                    _language_token_ranges(start, stop, text_token_tags)
+                )
+                if reference_quota_enabled:
+                    reference_ranges.extend(
+                        _vision_token_ranges(start, stop, text_token_tags)
+                    )
+            elif kind in ("ref_audio", "audio"):
+                protected_ranges.append((int(start), int(stop)))
+            elif (
+                reference_quota_enabled
+                and kind in ("cond", "ref_img", "ref_video", "video_ref")
+            ):
+                reference_ranges.append((int(start), int(stop)))
+            elif kind == "video" and prefix == 0:
+                prefix = int(start)
         to["_h3sla_prefix"] = prefix
+        to["_h3sla_protected_ranges"] = tuple(protected_ranges)
+        to["_h3sla_reference_ranges"] = tuple(reference_ranges)
+        to["_h3sla_stabilize_query_from"] = prefix
 
         step0 = state["step"] - 1  # 0-based, for dense_steps membership
         to["_h3sla_dense"] = bool(
@@ -629,7 +746,8 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
 
 def patch_h3_sla(model, sparsity_ratio=0.90, block_size=64, min_seq_len=8192,
                  dense_last_steps=0, protect_audio=True, dense_backend="comfy_kitchen",
-                 dense_steps="", disable_fp16_accum=True, stabilize_motion=False):
+                 dense_steps="", disable_fp16_accum=True, stabilize_motion=False,
+                 reference_protection="Off"):
     """Return a clone of ``model`` whose H3 self-attention runs block-sparse.
 
     Weights are untouched; this only installs an attention override and a
@@ -657,6 +775,14 @@ def patch_h3_sla(model, sparsity_ratio=0.90, block_size=64, min_seq_len=8192,
     to actual content -- visible on fast motion as a faint double-exposure.
     Off by default: it's a real fix for that specific symptom, not a general
     quality dial, and adds a small amount of state to carry between steps.
+
+    ``protect_audio`` is an all-or-nothing safety switch for language,
+    reference-audio, and target-audio ranges.
+
+    ``reference_protection`` controls a separate visual-reference quota:
+    ``Off`` leaves references to global top-k, ``True`` guarantees all of them,
+    and ``Light`` guarantees the best 15% of every reference range without
+    displacing ordinary video choices.
     """
     blkq = int(block_size)
     # BLKK=64 is not a typo. On sm_120 the 128x128 tile needs 160 KB of shared
@@ -667,6 +793,10 @@ def patch_h3_sla(model, sparsity_ratio=0.90, block_size=64, min_seq_len=8192,
 
     dense_fn = _resolve_backend(dense_backend)
     dense_step_set = _parse_step_spec(dense_steps)
+    reference_mode, reference_sparsity = _resolve_reference_sparsity(
+        reference_protection
+    )
+    protect_audio = _resolve_audio_protection(protect_audio)
 
     state = _new_state()
     patched = model.clone()
@@ -674,23 +804,28 @@ def patch_h3_sla(model, sparsity_ratio=0.90, block_size=64, min_seq_len=8192,
     to = patched.model_options.get("transformer_options", {}).copy()
     to["optimized_attention_override"] = _make_override(
         state, float(sparsity_ratio), blkq, blkk, int(min_seq_len),
-        bool(protect_audio), dense_fn=dense_fn,
-        stabilize_motion=bool(stabilize_motion))
+        protect_audio=protect_audio, dense_fn=dense_fn,
+        stabilize_motion=bool(stabilize_motion),
+        reference_sparsity=reference_sparsity)
     patched.model_options["transformer_options"] = to
 
     patched.add_wrapper_with_key(
         "diffusion_model", "h3_sla_state",
         _make_wrapper(state, float(sparsity_ratio), blkq, blkk,
                       int(dense_last_steps), dense_steps=dense_step_set,
-                      disable_fp16_accum=bool(disable_fp16_accum)),
+                      disable_fp16_accum=bool(disable_fp16_accum),
+                      reference_quota_enabled=reference_sparsity is not None),
     )
 
     log.info(
         "[H3Utils] SLA installed | sparsity=%.2f | BLK=%dx%d | min_seq_len=%d | "
         "dense_last_steps=%d | dense_steps=%s | dense_backend=%s | "
-        "protect_audio=%s | disable_fp16_accum=%s | stabilize_motion=%s",
+        "protect_audio=%s | reference_protection=%s%s | "
+        "disable_fp16_accum=%s | stabilize_motion=%s",
         sparsity_ratio, blkq, blkk, min_seq_len, dense_last_steps,
         sorted(dense_step_set) or "-", dense_backend, protect_audio,
+        reference_mode,
+        ("(%.2f)" % reference_sparsity) if reference_sparsity is not None else "",
         disable_fp16_accum, stabilize_motion,
     )
     return patched

--- a/ComfyUI-H3-SLA-Attention/sla_node.py
+++ b/ComfyUI-H3-SLA-Attention/sla_node.py
@@ -15,6 +15,7 @@ from comfy_api.latest import io
 log = logging.getLogger("H3Utils")
 
 BLOCK_SIZES = ("64", "128")
+REFERENCE_PROTECTION_MODES = ("True", "Light", "Off")
 # Matches kijai/ComfyUI-KJNodes' PatchSageAttentionKJ mode list exactly (see
 # sla/patch.py for the per-mode kernel + pv_accum_dtype each one calls),
 # plus this node's own "pytorch" / "comfy_kitchen" / "auto" choices.
@@ -111,13 +112,12 @@ class H3SLAAttention(io.ComfyNode):
                     label_on="protect", label_off="uniform (lightx2v parity)",
                     optional=True,
                     tooltip=(
-                        "Always attend the [text | cond | audio] prefix, "
-                        "whatever top-k picks. Audio is about 1% of the packed "
-                        "sequence -- 19 key blocks of 1794 at 768p/15s -- so "
-                        "plain top-k regularly drops all of it and the "
-                        "soundtrack degrades while the video still looks fine. "
-                        "Costs roughly 7%. Turn off only to reproduce "
-                        "lightx2v's uniform selection exactly.")),
+                        "Always attend blocks overlapping actual language "
+                        "tokens, target audio, and audio-reference segments. "
+                        "Visual-reference blocks are controlled separately. "
+                        "Disable only for LightX2V-style uniform sparsity; "
+                        "testing found partial or unprotected audio unstable "
+                        "for very little speed gain.")),
                 io.Boolean.Input("enabled", default=True,
                     label_on="sparse", label_off="dense (bypass)",
                     optional=True,
@@ -184,9 +184,24 @@ class H3SLAAttention(io.ComfyNode):
                         "Bias each layer's block selection toward what it "
                         "picked last step, so a near-tie between two blocks "
                         "doesn't flip for no reason and show up as a faint "
-                        "double-exposure on fast motion. Costs essentially "
-                        "nothing, but it's a fix for that one specific "
-                        "symptom, not a general quality dial ")),
+                        "double-exposure on fast motion. Only target-video "
+                        "query rows are stabilized; text and audio choices "
+                        "remain step-local. It is a fix for that one specific "
+                        "symptom, not a general quality dial.")),
+                io.Combo.Input("reference_protection",
+                    options=list(REFERENCE_PROTECTION_MODES), default="Off",
+                    optional=True,
+                    tooltip=(
+                        "Protect Image/Video Reference. True guarantees every "
+                        "Qwen vision-token, conditioning/image-reference, and "
+                        "video-reference block, "
+                        "matching the broad legacy prefix protection. Light "
+                        "uses fixed 0.85 reference sparsity and guarantees the "
+                        "best-scoring 15% of each visual-reference range. Off "
+                        "adds no special quota; "
+                        "references still participate in ordinary top-k. "
+                        "Default Off preserves the precise audio patch's "
+                        "fastest behaviour.")),
             ],
             outputs=[io.Model.Output()],
         )
@@ -195,7 +210,8 @@ class H3SLAAttention(io.ComfyNode):
     def execute(cls, model, sparsity_ratio=0.90, block_size="64",
                 min_seq_len=4096, dense_last_steps=1, protect_audio=True,
                 enabled=True, dense_steps="0", dense_backend="comfy_kitchen",
-                disable_fp16_accum=True, stabilize_motion=True) -> io.NodeOutput:
+                disable_fp16_accum=True, stabilize_motion=True,
+                reference_protection="Off") -> io.NodeOutput:
         if not enabled:
             log.info("[H3Utils] SLA disabled; model passed through unchanged.")
             return io.NodeOutput(model)
@@ -213,6 +229,7 @@ class H3SLAAttention(io.ComfyNode):
                 disable_fp16_accum=disable_fp16_accum,
                 protect_audio=protect_audio,
                 stabilize_motion=stabilize_motion,
+                reference_protection=reference_protection,
             )
         except Exception:                                # noqa: BLE001
             # Triton missing, an incompatible GPU, a ComfyUI API change -- none

--- a/ComfyUI-H3-SLA-Attention/tests/test_reference_quota.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_reference_quota.py
@@ -1,0 +1,81 @@
+"""Dependency-free tests for visual-reference quota arithmetic."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+def _load_block_map_helpers():
+    root = Path(__file__).resolve().parents[1]
+    source = root / "sla" / "block_map.py"
+
+    torch_stub = types.ModuleType("torch")
+    triton_stub = types.ModuleType("triton")
+    triton_stub.__path__ = []
+    triton_stub.jit = lambda function: function
+    language_stub = types.ModuleType("triton.language")
+
+    names = ("torch", "triton", "triton.language")
+    previous = {name: sys.modules.get(name) for name in names}
+    sys.modules["torch"] = torch_stub
+    sys.modules["triton"] = triton_stub
+    sys.modules["triton.language"] = language_stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "h3_sla_reference_quota_test", source
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, old_module in previous.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+
+block_map = _load_block_map_helpers()
+
+
+class ReferenceQuotaArithmetic(unittest.TestCase):
+    def test_block_map_uses_its_protect_ranges_argument(self):
+        code = block_map.get_block_map.__code__
+        self.assertIn("protect_ranges", code.co_varnames)
+        self.assertNotIn("protected_ranges", code.co_names)
+
+    def test_reference_ranges_exclude_already_protected_blocks(self):
+        ranges = block_map.get_reference_quota_block_ranges(
+            reference_ranges=((64, 192), (256, 512)),
+            protect_upto=0,
+            protected_ranges=((128, 320),),
+            BLKK=64,
+            NK=16,
+        )
+        self.assertEqual(ranges, ((1, 2), (5, 8)))
+
+    def test_legacy_protected_prefix_is_also_subtracted(self):
+        ranges = block_map.get_reference_quota_block_ranges(
+            reference_ranges=((0, 256),),
+            protect_upto=128,
+            protected_ranges=(),
+            BLKK=64,
+            NK=16,
+        )
+        self.assertEqual(ranges, ((2, 4),))
+
+    def test_manual_sparsity_rounds_up_to_the_promised_minimum(self):
+        keep = block_map.get_reference_quota_keep_count
+        self.assertEqual(keep(10, 0.80), 2)
+        self.assertEqual(keep(10, 0.90), 1)
+        self.assertEqual(keep(3, 0.0), 3)
+        self.assertEqual(keep(3, 0.99), 1)
+        self.assertEqual(keep(10, None), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ComfyUI-H3-SLA-Attention/tests/test_sla.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_sla.py
@@ -239,6 +239,47 @@ class StepWrapper(unittest.TestCase):
 @unittest.skipUnless(CUDA, "needs CUDA and triton")
 class Kernel(unittest.TestCase):
 
+    def test_light_reference_quota_guarantees_scored_reference_blocks(self):
+        from h3u.sla.block_map import get_block_map
+
+        S = 4096
+        reference = (512, 1536)  # 16 key blocks at BLKK=64
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+
+        _, plain_topk = get_block_map(q, k, 0.10, 64, 64)
+        lut, topk = get_block_map(
+            q, k, 0.10, 64, 64,
+            reference_ranges=(reference,),
+            reference_sparsity=0.85,
+        )
+
+        # ceil(15% of 16) = 3, added without displacing the global top-k.
+        self.assertEqual(topk, plain_topk + 3)
+        first, last = reference[0] // 64, reference[1] // 64
+        reference_count = ((lut.long() >= first) & (lut.long() < last)).sum(-1)
+        self.assertTrue((reference_count >= 3).all())
+
+    def test_motion_history_excludes_nonvideo_query_rows(self):
+        """Text/audio queries must not inherit motion choices between steps."""
+        from h3u.sla.block_map import get_block_map
+
+        S = 4096
+        video_start = 1024
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        lut, _, history = get_block_map(
+            q, k, 0.15, 64, 64, return_history=True,
+            stabilize_query_from=video_start,
+        )
+
+        first_video_query = (video_start + 63) // 64
+        self.assertEqual(
+            history.shape[-2], lut.shape[-2] - first_video_query
+        )
+
     def test_zero_sparsity_matches_dense_attention(self):
         """With every block kept, the sparse kernel is just attention."""
         from h3u.sla.block_map import get_block_map
@@ -295,6 +336,31 @@ class Kernel(unittest.TestCase):
         got = lut.long().sort(dim=-1).values[..., :n_pinned]
         want = torch.arange(n_pinned, device=lut.device)
         self.assertTrue(torch.equal(got, want.expand_as(got)))
+
+    def test_audio_range_does_not_pin_conditioning_prefix(self):
+        """Protect audio precisely instead of force-selecting refs before it."""
+        from h3u.sla.block_map import get_block_map
+
+        S = 16384
+        audio_start, audio_stop = 4096, 6144
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        lut, _ = get_block_map(
+            q, k, 0.05, 128, 64,
+            protect_ranges=((audio_start, audio_stop),),
+        )
+
+        first_audio = audio_start // 64
+        last_audio = audio_stop // 64
+        audio_blocks = torch.arange(first_audio, last_audio, device=lut.device)
+        has_audio = (lut.unsqueeze(-1).long() == audio_blocks).any(dim=-2)
+        self.assertTrue(has_audio.all(), "an audio block was not protected")
+
+        # There are more conditioning-prefix blocks than non-audio slots in
+        # this deliberately small top-k, so the full prefix cannot be pinned.
+        prefix_coverage = (lut.long() < first_audio).sum(dim=-1)
+        self.assertLess(prefix_coverage.max().item(), first_audio)
 
     def test_pinning_selects_the_same_blocks_at_zero_sparsity(self):
         """Pinning must decide *which* blocks, never alter their values.

--- a/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
@@ -40,6 +40,7 @@ def _load_patch_module():
     block_map.get_block_map = lambda *args, **kwargs: (_ for _ in ()).throw(
         AssertionError("attention routing is outside this wrapper-chain test")
     )
+    block_map.get_protected_block_ranges = lambda *args, **kwargs: ()
     sys.modules[block_map.__name__] = block_map
 
     kernel = types.ModuleType(f"{_PACKAGE}.sla.kernel")
@@ -83,6 +84,80 @@ class WrapperExecutor:
 
 
 class WrapperChainRegression(unittest.TestCase):
+    def test_reference_modes_resolve_to_fixed_sparsity(self):
+        self.assertEqual(
+            sla_patch._resolve_reference_sparsity("True"),
+            ("true", 0.0),
+        )
+        self.assertEqual(
+            sla_patch._resolve_reference_sparsity("Light"),
+            ("light", 0.85),
+        )
+        self.assertEqual(
+            sla_patch._resolve_reference_sparsity("Off"),
+            ("off", None),
+        )
+        # Experimental Manual workflows migrate to the audited fixed preset.
+        self.assertEqual(
+            sla_patch._resolve_reference_sparsity("Manual"),
+            ("light", 0.85),
+        )
+
+    def test_audio_protection_is_boolean_with_safe_string_migration(self):
+        self.assertTrue(sla_patch._resolve_audio_protection(True))
+        self.assertFalse(sla_patch._resolve_audio_protection(False))
+        self.assertTrue(sla_patch._resolve_audio_protection("True"))
+        self.assertFalse(sla_patch._resolve_audio_protection("Off"))
+        # A workflow saved while PR #1 exposed Manual becomes fully protected.
+        self.assertTrue(sla_patch._resolve_audio_protection("Manual"))
+        self.assertEqual(
+            sla_patch._resolve_audio_protection("false"),
+            False,
+        )
+
+    def test_language_and_audio_ranges_exclude_visual_reference_segments(self):
+        state = sla_patch._new_state()
+        sla_wrapper = sla_patch._make_wrapper(
+            state, 0.90, 64, 64, 0, reference_quota_enabled=True
+        )
+        seen = {}
+
+        class Layout:
+            segments = [
+                (0, 512, "text"),
+                (512, 8192, "ref_img"),
+                (8192, 9192, "ref_audio"),
+                (9192, 11192, "audio"),
+                (11192, 120000, "video"),
+            ]
+
+        def downstream(executor, *args, **kwargs):
+            seen.update(kwargs["transformer_options"])
+            return executor(*args, **kwargs)
+
+        executor = WrapperExecutor(
+            lambda *a, **k: None, [sla_wrapper, downstream]
+        )
+        executor.execute(
+            object(), object(), object(),
+            transformer_options={"sample_sigmas": [1.0, 0.0]},
+            minimax_payload={
+                "layout": Layout(),
+                "text_token_tags": [1] * 64 + [0] * 416 + [1] * 32,
+            },
+        )
+
+        self.assertEqual(
+            seen["_h3sla_protected_ranges"],
+            ((0, 64), (480, 512), (8192, 9192), (9192, 11192)),
+        )
+        self.assertEqual(
+            seen["_h3sla_reference_ranges"],
+            ((64, 480), (512, 8192)),
+        )
+        self.assertEqual(seen["_h3sla_prefix"], 11192)
+        self.assertEqual(seen["_h3sla_stabilize_query_from"], 11192)
+
     def test_sla_advances_to_downstream_wrapper_before_original(self):
         events = []
         state = sla_patch._new_state()

--- a/js/h3_sla_attention.js
+++ b/js/h3_sla_attention.js
@@ -1,0 +1,41 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_TYPE = "H3SLAAttention";
+
+app.registerExtension({
+    name: "PlagueKind.H3SLAAttention.ReferenceProtection",
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name !== NODE_TYPE) return;
+
+        const originalOnNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function () {
+            const result = originalOnNodeCreated?.apply(this, arguments);
+            const node = this;
+
+            function applyReferenceLabel() {
+                const referenceMode = node.widgets?.find(
+                    widget => widget.name === "reference_protection"
+                );
+                const protectAudio = node.widgets?.find(
+                    widget => widget.name === "protect_audio"
+                );
+                if (referenceMode) {
+                    referenceMode.label = "Protect Image/Video Reference";
+                    if (String(referenceMode.value).toLowerCase() === "manual") {
+                        referenceMode.value = "Light";
+                    }
+                }
+                if (protectAudio && typeof protectAudio.value === "string") {
+                    const disabled = ["off", "false", "0", "no"].includes(
+                        protectAudio.value.toLowerCase()
+                    );
+                    protectAudio.value = !disabled;
+                }
+                node.graph?.setDirtyCanvas(true, true);
+            }
+
+            requestAnimationFrame(applyReferenceLabel);
+            return result;
+        };
+    },
+});


### PR DESCRIPTION
Based on current upstream v1.3.9 (c77f9e1). Protect Audio remains the original Boolean and defaults to enabled; it precisely pins actual language, reference-audio, and target-audio ranges without also pinning large visual-reference prefixes. Partial audio sparsification is intentionally omitted because testing found audio instability for little speed gain. Protect Image/Video Reference adds True, Light, and Off: True fully guarantees all detected visual ranges, Light uses fixed 0.85 sparsity independently for Qwen vision-token, conditioning/image-reference, and video-reference ranges, and Off leaves them to ordinary global top-k. The reference quota is additive and does not evict ordinary video selections. Motion history remains scoped to target-video queries. This also fixes the protect_ranges variable-name error that could make enabled visual protection fall back to dense attention. Validation: 33 unittest cases ran successfully on this host, with 21 CUDA/Triton-dependent cases skipped; Python and JavaScript syntax checks and git diff checks passed.