### PR TITLE
Bound and reset H3 SLA motion history

### DIFF
--- a/ComfyUI-H3-SLA-Attention/sla/block_map.py
+++ b/ComfyUI-H3-SLA-Attention/sla/block_map.py
@@ -88,10 +88,16 @@ def mean_pool(x, BLK):
 # still wins, big enough to kill a near-tie flip between steps that isn't
 # telling you anything real.
 _STICKY_BONUS_FRAC = 0.05
+# Only selections close to the top-k cutoff can realistically flip on the next
+# step. Keeping the complete LUT for all 50 H3 layers makes stabilization state
+# scale as O(NQ * topk) and can retain several GB of VRAM at 768p. Eight
+# boundary entries per query row preserve the intended hysteresis while making
+# the retained state O(NQ) with a small constant.
+_STICKY_HISTORY_WIDTH = 8
 
 
 def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
-                  prev_lut=None):
+                  prev_lut=None, return_history=False):
     """Return ``(lut, topk)``: the key blocks each query block should attend to.
 
     ``q``/``k`` are ``(B, L, H, D)`` contiguous. ``lut`` comes back as
@@ -105,15 +111,19 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
     are added on top of the top-k budget rather than displacing video, so video
     coverage is unchanged and the extra cost is the prefix itself (~7%).
 
-    ``prev_lut``, when given the previous call's ``lut`` for this same layer,
-    nudges those blocks' scores up before top-k -- pure per-step top-k has no
-    memory, so on a near-tie between two similarly-scored blocks the winner
-    can flip step to step for no reason tied to actual content, and on fast
-    motion that shows up as a faint double-exposure rather than one clean
-    pick. The nudge only breaks a close call; a block that's actually a
-    better fit this step still wins. Silently ignored if its shape doesn't
-    match this call's (e.g. right after a dense step, or the first sparse
-    call of a run).
+    ``prev_lut``, when given the previous call's bounded history for this same
+    layer, nudges those blocks' scores up before top-k -- pure per-step top-k
+    has no memory, so on a near-tie between two similarly-scored blocks the
+    winner can flip step to step for no reason tied to actual content, and on
+    fast motion that shows up as a faint double-exposure rather than one clean
+    pick. The nudge only breaks a close call; a block that's actually a better
+    fit this step still wins. Silently ignored if its shape doesn't match this
+    call's (e.g. after a resolution change or the first sparse call of a run).
+
+    With ``return_history=True``, also return a compact LUT containing only the
+    selected blocks closest to the top-k cutoff. Strong selections do not need
+    a sticky bonus; retaining them was the source of multi-GB stabilization
+    state at long H3 sequence lengths.
     """
     pooled_q = mean_pool(q, BLKQ)
     # Smooth-k (SageAttention's trick), folded in rather than materialised.
@@ -150,6 +160,22 @@ def get_block_map(q, k, topk_ratio, BLKQ=128, BLKK=128, protect_upto=0,
             pooled_score[..., :n_pinned] = float("inf")
             topk = min(NK, topk + n_pinned)
 
-    lut = torch.topk(pooled_score, topk, dim=-1, sorted=False).indices
+    selected = torch.topk(pooled_score, topk, dim=-1, sorted=False)
+    lut = selected.indices
+    lut_i32 = lut.to(torch.int32).contiguous()
 
-    return lut.to(torch.int32).contiguous(), topk
+    if not return_history:
+        return lut_i32, topk
+
+    history_width = min(_STICKY_HISTORY_WIDTH, topk)
+    if history_width == topk:
+        history = lut
+    else:
+        # The lowest scores inside the selected set sit at the top-k boundary
+        # and are the only entries likely to flip membership on the next step.
+        boundary_pos = torch.topk(
+            selected.values, history_width, dim=-1, largest=False, sorted=False
+        ).indices
+        history = torch.gather(lut, -1, boundary_pos)
+
+    return lut_i32, topk, history.to(torch.int32).contiguous()

--- a/ComfyUI-H3-SLA-Attention/sla/patch.py
+++ b/ComfyUI-H3-SLA-Attention/sla/patch.py
@@ -231,7 +231,7 @@ def _new_state():
         "failed": None,    # first kernel failure, if any
         "fp16_saved": None,     # (fp16, bf16) matmul reduction flags to restore
         "call_idx": 0,       # this step's call count, for stabilize_motion
-        "prev_lut": {},      # call_idx -> last sparse lut, for stabilize_motion
+        "prev_lut": {},      # call_idx -> bounded boundary LUT for motion stability
     }
 
 
@@ -248,6 +248,10 @@ def _reset_run_state(state):
     state["blocks"] = 0
     state["pinned"] = 0
     state["failed"] = None
+    state["call_idx"] = 0
+    # The history is generation-local. Besides preventing one video's block
+    # choices from biasing the next, clearing it releases retained GPU tensors.
+    state["prev_lut"].clear()
 
 
 def _summarise(state, sparsity, blkq, blkk):
@@ -285,13 +289,12 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
     is set globally; the sparse path is unaffected either way, since it
     never calls ``func`` at all.
 
-    ``stabilize_motion`` carries each layer's previously-selected key blocks
-    into ``get_block_map`` as a tie-breaker (see block_map.py); it costs one
-    small dict lookup and store per call, nothing else. ``state["call_idx"]``
-    is the layer identity this relies on -- it counts calls within the
-    current step, reset to 0 by the wrapper at the top of every step, and it
-    works because the model graph is static: the Nth attention call happens
-    in the same layer every step.
+    ``stabilize_motion`` carries a bounded set of each layer's near-cutoff key
+    blocks into ``get_block_map`` as a tie-breaker (see block_map.py).
+    ``state["call_idx"]`` is the layer identity this relies on -- it counts
+    calls within the current step, reset to 0 by the wrapper at the top of
+    every step, and it works because the model graph is static: the Nth
+    attention call happens in the same layer every step.
     """
     topk_ratio = 1.0 - sparsity_ratio
 
@@ -350,10 +353,18 @@ def _make_override(state, sparsity_ratio, blkq, blkk, min_seq_len,
             state["call_idx"] = call_idx + 1
             prev_lut = state["prev_lut"].get(call_idx) if stabilize_motion else None
 
-            lut, topk = get_block_map(qb, kb, topk_ratio, blkq, blkk,
-                                      protect_upto=prefix, prev_lut=prev_lut)
             if stabilize_motion:
-                state["prev_lut"][call_idx] = lut
+                lut, topk, history_lut = get_block_map(
+                    qb, kb, topk_ratio, blkq, blkk,
+                    protect_upto=prefix, prev_lut=prev_lut,
+                    return_history=True,
+                )
+                state["prev_lut"][call_idx] = history_lut
+            else:
+                lut, topk = get_block_map(
+                    qb, kb, topk_ratio, blkq, blkk,
+                    protect_upto=prefix,
+                )
             out = block_sparse_attention(qb, kb, vb, lut, topk, blkq, blkk)
 
             state["calls"] += 1
@@ -589,6 +600,9 @@ def _make_wrapper(state, sparsity_ratio, blkq, blkk, dense_last_steps,
                 if orig_bf16 is not None:
                     backend.allow_bf16_reduced_precision_reduction = orig_bf16
                 state["fp16_saved"] = None
+            # Do not retain GPU-resident motion history while ComfyUI is idle,
+            # and never carry one video's selections into the next video.
+            state["prev_lut"].clear()
         return out
 
     return wrapper

--- a/ComfyUI-H3-SLA-Attention/sla_node.py
+++ b/ComfyUI-H3-SLA-Attention/sla_node.py
@@ -184,9 +184,10 @@ class H3SLAAttention(io.ComfyNode):
                         "Bias each layer's block selection toward what it "
                         "picked last step, so a near-tie between two blocks "
                         "doesn't flip for no reason and show up as a faint "
-                        "double-exposure on fast motion. Costs essentially "
-                        "nothing, but it's a fix for that one specific "
-                        "symptom, not a general quality dial ")),
+                        "double-exposure on fast motion. Keeps a bounded set "
+                        "of near-cutoff block choices per layer; it is a fix "
+                        "for that one specific symptom, not a general quality "
+                        "dial.")),
             ],
             outputs=[io.Model.Output()],
         )

--- a/ComfyUI-H3-SLA-Attention/tests/test_sla.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_sla.py
@@ -239,6 +239,24 @@ class StepWrapper(unittest.TestCase):
 @unittest.skipUnless(CUDA, "needs CUDA and triton")
 class Kernel(unittest.TestCase):
 
+    def test_motion_history_is_bounded_and_selected(self):
+        """Motion stabilization must not retain the complete per-layer LUT."""
+        from h3u.sla.block_map import get_block_map
+
+        S = 4096
+        torch.manual_seed(0)
+        q = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, S, H, D, device="cuda", dtype=torch.bfloat16)
+        lut, topk, history = get_block_map(
+            q, k, 0.15, 64, 64, return_history=True
+        )
+
+        self.assertEqual(history.shape[:-1], lut.shape[:-1])
+        self.assertLessEqual(history.shape[-1], 8)
+        self.assertLess(history.shape[-1], topk)
+        is_selected = (history.unsqueeze(-1) == lut.unsqueeze(-2)).any(dim=-1)
+        self.assertTrue(is_selected.all())
+
     def test_zero_sparsity_matches_dense_attention(self):
         """With every block kept, the sparse kernel is just attention."""
         from h3u.sla.block_map import get_block_map

--- a/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
+++ b/ComfyUI-H3-SLA-Attention/tests/test_wrapper_chain.py
@@ -83,6 +83,36 @@ class WrapperExecutor:
 
 
 class WrapperChainRegression(unittest.TestCase):
+    def test_run_reset_clears_motion_history(self):
+        """GPU LUTs and choices from one video must not survive its run."""
+
+        state = sla_patch._new_state()
+        marker = object()
+        state["prev_lut"][0] = marker
+        state["call_idx"] = 17
+
+        sla_patch._reset_run_state(state)
+
+        self.assertEqual(state["prev_lut"], {})
+        self.assertEqual(state["call_idx"], 0)
+
+    def test_end_of_run_releases_motion_history(self):
+        """Release history immediately rather than waiting for another run."""
+
+        state = sla_patch._new_state()
+        state["prev_lut"][0] = object()
+        sla_wrapper = sla_patch._make_wrapper(state, 0.90, 64, 64, 0)
+        executor = WrapperExecutor(lambda *a, **k: None, [sla_wrapper])
+
+        executor.execute(
+            object(),
+            object(),
+            object(),
+            transformer_options={"sample_sigmas": [1.0, 0.0]},
+        )
+
+        self.assertEqual(state["prev_lut"], {})
+
     def test_sla_advances_to_downstream_wrapper_before_original(self):
         events = []
         state = sla_patch._new_state()


### PR DESCRIPTION
## Summary

- retain only eight near-cutoff block selections per query row for motion stabilization
- clear GPU-resident stabilization history at run reset and completion
- keep stabilize_motion enabled by default in both the node schema and execution path
- add bounded-history and lifecycle regression coverage

## Why

The existing stabilization state stores every selected key block for every query row and layer. At high resolution this scales with the full sparse LUT and can retain several GiB of VRAM. Only choices near the top-k cutoff can plausibly flip next step, so a bounded boundary history preserves the intended hysteresis without retaining the full LUT or leaking it between videos.

## Validation

- python -m unittest discover -s ComfyUI-H3-SLA-Attention/tests -p test_*.py: 26 passed/skipped as expected (19 CUDA/Triton tests skipped on this host)
- python -m compileall -q ComfyUI-H3-SLA-Attention
- git diff --check