### PR TITLE
Fix Ultimate Upscale for extend context keyframes

### DIFF
--- a/ComfyUI-H3-UltimateUpscale-LD/nodes.py
+++ b/ComfyUI-H3-UltimateUpscale-LD/nodes.py
@@ -450,7 +450,7 @@ def crop_keyframes_to_tile(cond, src_h, src_w, r0, c0, tr, tc):
 
 
 def trim_keyframe(kf, f0, f1):
-    """Copy a keyframe cut to the portion fully inside pixel frames [f0, f1)."""
+    """Copy/rebase one keyframe for target pixel frames ``[f0, f1)``."""
     kind = kf.get("kind")
     if kind in ("context", "context_audio"):
         # Extend conditioning places these rows immediately BEFORE the target's
@@ -458,6 +458,21 @@ def trim_keyframe(kf, f0, f1):
         # them for the first temporal chunk only. Later chunks are anchored to
         # the preceding re-sampled result by anchor_conditioning(), and keeping
         # the original context there would incorrectly replay it at every seam.
+        latent_key = "latent" if kind == "context" else "audio_latent"
+        time_axis = 2 if kind == "context" else -1
+        latent = kf.get(latent_key)
+        num_frames = kf.get("num_frames")
+        if latent is None or num_frames is None:
+            raise ValueError(
+                f"MiniMax H3 {kind} keyframe requires both '{latent_key}' "
+                "and 'num_frames'."
+            )
+        actual_frames = int(latent.shape[time_axis])
+        if int(num_frames) != actual_frames:
+            raise ValueError(
+                f"MiniMax H3 {kind} keyframe declares num_frames={num_frames}, "
+                f"but its {latent_key} contains {actual_frames} temporal frames."
+            )
         return dict(kf) if f0 == 0 else None
 
     if "resolved_frame_index" not in kf:

--- a/ComfyUI-H3-UltimateUpscale-LD/nodes.py
+++ b/ComfyUI-H3-UltimateUpscale-LD/nodes.py
@@ -467,7 +467,15 @@ def trim_keyframe(kf, f0, f1):
                 f"MiniMax H3 {kind} keyframe requires both '{latent_key}' "
                 "and 'num_frames'."
             )
+        expected_ndim = 5 if kind == "context" else 4
+        if getattr(latent, "ndim", None) != expected_ndim:
+            raise ValueError(
+                f"MiniMax H3 {kind} keyframe '{latent_key}' must be a "
+                f"{expected_ndim}D tensor; got {getattr(latent, 'ndim', None)!r}D."
+            )
         actual_frames = int(latent.shape[time_axis])
+        if actual_frames <= 0:
+            raise ValueError(f"MiniMax H3 {kind} keyframe contains no temporal frames.")
         if int(num_frames) != actual_frames:
             raise ValueError(
                 f"MiniMax H3 {kind} keyframe declares num_frames={num_frames}, "

--- a/ComfyUI-H3-UltimateUpscale-LD/nodes.py
+++ b/ComfyUI-H3-UltimateUpscale-LD/nodes.py
@@ -451,6 +451,22 @@ def crop_keyframes_to_tile(cond, src_h, src_w, r0, c0, tr, tc):
 
 def trim_keyframe(kf, f0, f1):
     """Copy a keyframe cut to the portion fully inside pixel frames [f0, f1)."""
+    kind = kf.get("kind")
+    if kind in ("context", "context_audio"):
+        # Extend conditioning places these rows immediately BEFORE the target's
+        # frame 0, so they intentionally have no resolved_frame_index. Preserve
+        # them for the first temporal chunk only. Later chunks are anchored to
+        # the preceding re-sampled result by anchor_conditioning(), and keeping
+        # the original context there would incorrectly replay it at every seam.
+        return dict(kf) if f0 == 0 else None
+
+    if "resolved_frame_index" not in kf:
+        raise ValueError(
+            "MiniMax H3 keyframe is missing 'resolved_frame_index' "
+            f"(kind={kind!r}); only extend context/context_audio keyframes may "
+            "omit an absolute target-frame position."
+        )
+
     idx = kf["resolved_frame_index"]
     latent = kf.get("latent")
     audio_latent = kf.get("audio_latent")
@@ -500,6 +516,12 @@ def reanchor_conditioning(cond, f0, f1, spatial=None):
         nd = dict(d)
         kfs = nd.get("minimax_keyframes")
         if kfs:
+            # Keyframe indices below are rebased from the full target onto this
+            # chunk. PackedLayout validates a local last-frame anchor against
+            # frame_count - 1, so the count must be rebased at the same time.
+            # Keep it even when no original keyframe survives: a later
+            # anchor_conditioning() call may insert a local frame-0 anchor.
+            nd["minimax_frame_count"] = f1 - f0
             trimmed = [trim_keyframe(kf, f0, f1) for kf in kfs]
             trimmed = [kf for kf in trimmed if kf is not None]
             if trimmed:
@@ -509,8 +531,8 @@ def reanchor_conditioning(cond, f0, f1, spatial=None):
                         if lt is not None and (lt.shape[3] != spatial[0] or lt.shape[4] != spatial[1]):
                             B, C, T, H, W = lt.shape
                             kf["latent"] = F.interpolate(
-                                lt.view(B * T, C, H, W), size=spatial, mode="bilinear", align_corners=False
-                            ).view(B, C, T, spatial[0], spatial[1])
+                                lt.reshape(B * T, C, H, W), size=spatial, mode="bilinear", align_corners=False
+                            ).reshape(B, C, T, spatial[0], spatial[1])
                 nd["minimax_keyframes"] = trimmed
             else:
                 nd.pop("minimax_keyframes", None)

--- a/ComfyUI-H3-UltimateUpscale-LD/nodes.py
+++ b/ComfyUI-H3-UltimateUpscale-LD/nodes.py
@@ -467,6 +467,11 @@ def trim_keyframe(kf, f0, f1):
                 f"MiniMax H3 {kind} keyframe requires both '{latent_key}' "
                 "and 'num_frames'."
             )
+        if not isinstance(num_frames, int) or isinstance(num_frames, bool):
+            raise ValueError(
+                f"MiniMax H3 {kind} keyframe 'num_frames' must be an integer; "
+                f"got {type(num_frames).__name__}."
+            )
         expected_ndim = 5 if kind == "context" else 4
         if getattr(latent, "ndim", None) != expected_ndim:
             raise ValueError(
@@ -476,7 +481,7 @@ def trim_keyframe(kf, f0, f1):
         actual_frames = int(latent.shape[time_axis])
         if actual_frames <= 0:
             raise ValueError(f"MiniMax H3 {kind} keyframe contains no temporal frames.")
-        if int(num_frames) != actual_frames:
+        if num_frames != actual_frames:
             raise ValueError(
                 f"MiniMax H3 {kind} keyframe declares num_frames={num_frames}, "
                 f"but its {latent_key} contains {actual_frames} temporal frames."

--- a/tests/test_mmh3_extend_context_trim.py
+++ b/tests/test_mmh3_extend_context_trim.py
@@ -58,6 +58,20 @@ class ExtendContextTrimTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "contains 20 temporal frames"):
             module.trim_keyframe(mismatched, 0, 85)
 
+        with self.assertRaisesRegex(ValueError, "must be a 5D tensor"):
+            module.trim_keyframe({
+                "kind": "context",
+                "num_frames": 2,
+                "latent": torch.zeros(2, 2),
+            }, 0, 85)
+
+        with self.assertRaisesRegex(ValueError, "contains no temporal frames"):
+            module.trim_keyframe({
+                "kind": "context_audio",
+                "num_frames": 0,
+                "audio_latent": torch.zeros(1, 32, 2, 0),
+            }, 0, 85)
+
     def test_regular_absolute_keyframe_behavior_is_unchanged(self):
         latent = torch.randn(1, 16, 1, 4, 4)
         keyframe = {"resolved_frame_index": 0, "latent": latent}

--- a/tests/test_mmh3_extend_context_trim.py
+++ b/tests/test_mmh3_extend_context_trim.py
@@ -72,6 +72,15 @@ class ExtendContextTrimTests(unittest.TestCase):
                 "audio_latent": torch.zeros(1, 32, 2, 0),
             }, 0, 85)
 
+        for invalid in (3.7, "3", True):
+            with self.subTest(num_frames=invalid):
+                with self.assertRaisesRegex(ValueError, "num_frames' must be an integer"):
+                    module.trim_keyframe({
+                        "kind": "context",
+                        "num_frames": invalid,
+                        "latent": torch.zeros(1, 16, 3, 2, 2),
+                    }, 0, 85)
+
     def test_regular_absolute_keyframe_behavior_is_unchanged(self):
         latent = torch.randn(1, 16, 1, 4, 4)
         keyframe = {"resolved_frame_index": 0, "latent": latent}

--- a/tests/test_mmh3_extend_context_trim.py
+++ b/tests/test_mmh3_extend_context_trim.py
@@ -1,0 +1,115 @@
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NODES_PATH = REPO_ROOT / "ComfyUI-H3-UltimateUpscale-LD" / "nodes.py"
+default_comfy_root = Path(__file__).resolve().parents[3]
+COMFY_ROOT = Path(os.environ.get("COMFYUI_ROOT", default_comfy_root))
+if not (COMFY_ROOT / "comfy").is_dir() or not (COMFY_ROOT / "folder_paths.py").is_file():
+    raise RuntimeError(
+        "Set COMFYUI_ROOT to a ComfyUI checkout before running this test "
+        f"(resolved {COMFY_ROOT!s})."
+    )
+
+sys.path.insert(0, str(COMFY_ROOT))
+spec = importlib.util.spec_from_file_location("plaguekind_upscale_pr_nodes", NODES_PATH)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class ExtendContextTrimTests(unittest.TestCase):
+    def test_context_is_kept_only_for_first_temporal_chunk(self):
+        latent = torch.randn(1, 16, 2, 4, 4)
+        keyframe = {"kind": "context", "num_frames": 2, "latent": latent}
+
+        first = module.trim_keyframe(keyframe, 0, 85)
+        self.assertIsNot(first, keyframe)
+        self.assertEqual(first["kind"], "context")
+        self.assertEqual(first["num_frames"], 2)
+        self.assertIs(first["latent"], latent)
+        self.assertNotIn("resolved_frame_index", first)
+        self.assertIsNone(module.trim_keyframe(keyframe, 68, 153))
+
+    def test_context_audio_is_kept_only_for_first_temporal_chunk(self):
+        audio = torch.randn(1, 32, 2, 20)
+        keyframe = {"kind": "context_audio", "num_frames": 20, "audio_latent": audio}
+
+        first = module.trim_keyframe(keyframe, 0, 85)
+        self.assertEqual(first["kind"], "context_audio")
+        self.assertIs(first["audio_latent"], audio)
+        self.assertIsNone(module.trim_keyframe(keyframe, 68, 153))
+
+    def test_context_payload_requires_matching_declared_length(self):
+        with self.assertRaisesRegex(ValueError, "requires both 'latent' and 'num_frames'"):
+            module.trim_keyframe({"kind": "context", "num_frames": 2}, 0, 85)
+
+        mismatched = {
+            "kind": "context_audio",
+            "num_frames": 19,
+            "audio_latent": torch.zeros(1, 32, 2, 20),
+        }
+        with self.assertRaisesRegex(ValueError, "contains 20 temporal frames"):
+            module.trim_keyframe(mismatched, 0, 85)
+
+    def test_regular_absolute_keyframe_behavior_is_unchanged(self):
+        latent = torch.randn(1, 16, 1, 4, 4)
+        keyframe = {"resolved_frame_index": 0, "latent": latent}
+        trimmed = module.trim_keyframe(keyframe, 0, 17)
+
+        self.assertEqual(trimmed["resolved_frame_index"], 0)
+        self.assertTrue(torch.equal(trimmed["latent"], latent))
+
+    def test_unknown_unpositioned_keyframe_fails_clearly(self):
+        with self.assertRaisesRegex(ValueError, "missing 'resolved_frame_index'"):
+            module.trim_keyframe({"kind": "mystery", "latent": torch.zeros(1, 16, 1, 2, 2)}, 0, 17)
+
+    def test_last_frame_anchor_and_frame_count_are_rebased_together(self):
+        last = {"resolved_frame_index": 169, "latent": torch.zeros(1, 16, 1, 2, 2)}
+        cond = [[torch.zeros(1), {
+            "minimax_keyframes": [last],
+            "minimax_frame_count": 170,
+        }]]
+
+        rebased = module.reanchor_conditioning(cond, 85, 170)
+        metadata = rebased[0][1]
+        self.assertEqual(metadata["minimax_frame_count"], 85)
+        self.assertEqual(metadata["minimax_keyframes"][0]["resolved_frame_index"], 84)
+
+    def test_noncontiguous_context_latent_can_be_spatially_resized(self):
+        source = torch.randn(1, 16, 6, 4, 6)
+        noncontiguous = source[:, :, 3:, :, :]
+        self.assertFalse(noncontiguous.is_contiguous())
+        context = {"kind": "context", "num_frames": 3, "latent": noncontiguous}
+        cond = [[torch.zeros(1), {
+            "minimax_keyframes": [context],
+            "minimax_frame_count": 85,
+        }]]
+
+        rebased = module.reanchor_conditioning(cond, 0, 85, spatial=(8, 10))
+        latent = rebased[0][1]["minimax_keyframes"][0]["latent"]
+        self.assertEqual(tuple(latent.shape), (1, 16, 3, 8, 10))
+
+    def test_reanchor_conditioning_drops_original_context_after_first_chunk(self):
+        context = {"kind": "context", "num_frames": 1, "latent": torch.zeros(1, 16, 1, 2, 2)}
+        anchor = {"resolved_frame_index": 68, "latent": torch.zeros(1, 16, 1, 2, 2)}
+        cond = [[torch.zeros(1), {"minimax_keyframes": [context, anchor]}]]
+
+        first = module.reanchor_conditioning(cond, 0, 85)
+        self.assertEqual([kf.get("kind") for kf in first[0][1]["minimax_keyframes"]], ["context", None])
+
+        later = module.reanchor_conditioning(cond, 68, 153)
+        later_keyframes = later[0][1]["minimax_keyframes"]
+        self.assertEqual(len(later_keyframes), 1)
+        self.assertNotIn("kind", later_keyframes[0])
+        self.assertEqual(later_keyframes[0]["resolved_frame_index"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #16.

## Summary
- accept MiniMax extend `context` / `context_audio` keyframes that intentionally have no `resolved_frame_index`
- preserve that pre-extension context only for the first temporal chunk
- validate required metadata, strict integer frame counts, tensor rank and declared temporal length
- rebase `minimax_frame_count` together with absolute keyframe indices
- resize non-contiguous temporal keyframe slices safely with `reshape`
- fail clearly for unsupported unpositioned keyframe kinds

## Why context is first-chunk-only
The extend patch positions context rows immediately before the local target origin. Reusing the original context in every temporal chunk would replay it at every seam. Later chunks already receive the previous upscaled video result as a local frame-0 anchor.

Audio is passed through unchanged by MMH3 Ultimate Upscale: each `chunk_a` is cut from the original global audio and the sampler's audio output is discarded before `temporal_append`. Therefore later chunks do not need a synthetic previous-chunk audio anchor.

## Validation
The PR includes `tests/test_mmh3_extend_context_trim.py`. Run it inside a ComfyUI environment (set `COMFYUI_ROOT` when the checkout is not under `ComfyUI/custom_nodes`). Eight tests cover:
- context/context_audio retained only in the first chunk
- missing fields, float/string/bool frame counts, wrong tensor rank, empty time axes and mismatched lengths rejected clearly
- normal absolute keyframe behavior unchanged
- unsupported unpositioned kinds rejected
- reanchor flow across first/later chunks
- global last anchor and frame_count rebase together (`169/170` -> `84/85`)
- a real non-contiguous temporal slice resizes from `(1,16,3,4,6)` to `(1,16,3,8,10)` without stride errors

The runtime `nodes.py` blob and locally tested installation blob are byte-identical. Independent review also checked dtype/device preservation, numerical equivalence and autograd through the `reshape` copy path. An additional local matrix covers 9 timing configurations / 24 temporal chunks plus the exact installed Extend context contract.